### PR TITLE
Define invalid stream id to be 0

### DIFF
--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -4,7 +4,7 @@
 #include <aws/iotdevice/secure_tunneling.h>
 
 #define MAX_WEBSOCKET_PAYLOAD 131076
-#define INVALID_STREAM_ID (-1)
+#define INVALID_STREAM_ID 0
 
 /* TODO: Remove me */
 #define UNUSED(x) (void)(x)


### PR DESCRIPTION
`INVALID_STREAM_ID` was incorrectly defined as `-1`. Per secure tunneling team, it should be `0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
