### PR TITLE
Setting null terminator char for destination after strncpy.

### DIFF
--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -359,6 +359,7 @@ int get_network_config_and_transfer(struct aws_iotdevice_network_ifconfig *ifcon
         AWS_ZERO_STRUCT(ifr);
 
         strncpy(ifr.ifr_name, address->ifa_name, IFNAMSIZ);
+        ifr.ifr_name[IFNAMSIZ - 1] = 0;
         fd = socket(AF_INET, SOCK_DGRAM, 0);
         if (fd == -1) {
             AWS_LOGF_ERROR(
@@ -389,6 +390,7 @@ int get_network_config_and_transfer(struct aws_iotdevice_network_ifconfig *ifcon
             inet_ntop(AF_INET, &((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr, iface->ipv4_addr_str, 16);
         }
         strncpy(iface->iface_name, ifr.ifr_name, IFACE_NAME_SIZE);
+        iface->iface_name[IFACE_NAME_SIZE - 1] = 0;
 
         if (address->ifa_data) {
             struct rtnl_link_stats *stats = address->ifa_data;


### PR DESCRIPTION
*Description of changes:*

- Fixing the stringop-truncation warning by adding a null terminator after strncpy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
