### PR TITLE
Add first unit test for secure tunneling

### DIFF
--- a/source/iotdevice.c
+++ b/source/iotdevice.c
@@ -46,7 +46,8 @@ static struct aws_error_info_list s_error_list = {
 /* clang-format off */
         static struct aws_log_subject_info s_logging_subjects[] = {
             DEFINE_LOG_SUBJECT_INFO(AWS_LS_IOTDEVICE_DEFENDER_TASK, "iotdevice-defender", "IoT DeviceDefender"),
-            DEFINE_LOG_SUBJECT_INFO(AWS_LS_IOTDEVICE_NETWORK_CONFIG, "iotdevice-network", "IoT Device Network")
+            DEFINE_LOG_SUBJECT_INFO(AWS_LS_IOTDEVICE_NETWORK_CONFIG, "iotdevice-network", "IoT Device Network"),
+            DEFINE_LOG_SUBJECT_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "iotdevice-st", "IoT Secure Tunneling"),
         };
 /* clang-format on */
 

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -159,7 +159,7 @@ static void s_process_received_data(struct aws_secure_tunnel *secure_tunnel) {
     }
 }
 
-static bool s_on_websocket_incoming_frame_payload(
+bool on_websocket_incoming_frame_payload(
     struct aws_websocket *websocket,
     const struct aws_websocket_incoming_frame *frame,
     struct aws_byte_cursor data,
@@ -244,7 +244,7 @@ static void s_init_websocket_client_connection_options(
     websocket_options->on_connection_setup = s_on_websocket_setup;
     websocket_options->on_connection_shutdown = s_on_websocket_shutdown;
     websocket_options->on_incoming_frame_begin = s_on_websocket_incoming_frame_begin;
-    websocket_options->on_incoming_frame_payload = s_on_websocket_incoming_frame_payload;
+    websocket_options->on_incoming_frame_payload = on_websocket_incoming_frame_payload;
     websocket_options->on_incoming_frame_complete = s_on_websocket_incoming_frame_complete;
     websocket_options->manual_window_management = false;
 
@@ -328,11 +328,8 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
 }
 
 void aws_secure_tunnel_release(struct aws_secure_tunnel *secure_tunnel) {
-    secure_tunnel->vtable.close(secure_tunnel);
-
+    aws_byte_buf_clean_up(&secure_tunnel->received_data);
     aws_tls_connection_options_clean_up(&secure_tunnel->tls_con_opt);
     aws_tls_ctx_release(secure_tunnel->tls_ctx);
-    aws_byte_buf_clean_up(&secure_tunnel->received_data);
-
     aws_mem_release(secure_tunnel->config.allocator, secure_tunnel);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(AwsTestHarness)
 enable_testing()
 
 file(GLOB TEST_HDRS "mqtt_mock_structs.h")
-set(TEST_SRC metrics_tests.c)
+set(TEST_SRC metrics_tests.c secure_tunneling_tests.c)
 file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
 add_test_case(devicedefender_task_unsupported_report_format)
@@ -13,6 +13,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(devicedefender_get_system_network_total)
     add_test_case(devicedefender_get_network_connections)
     add_test_case(devicedefender_success_test)
+    add_test_case(secure_tunneling_handle_stream_start_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -1,0 +1,126 @@
+#include <aws/common/zero.h>
+#include <aws/http/http.h>
+#include <aws/io/channel_bootstrap.h>
+#include <aws/io/event_loop.h>
+#include <aws/io/socket.h>
+#include <aws/iotdevice/iotdevice.h>
+#include <aws/iotdevice/private/serializer.h>
+#include <aws/iotdevice/secure_tunneling.h>
+#include <aws/testing/aws_test_harness.h>
+
+#define ACCESS_TOKEN "access_token"
+#define ENDPOINT "data.tunneling.iot.us-west-2.amazonaws.com"
+
+/* Callback when websocket gets data. The tests here are calling this function directly. */
+struct aws_websocket_incoming_frame;
+extern bool on_websocket_incoming_frame_payload(
+    struct aws_websocket *websocket,
+    const struct aws_websocket_incoming_frame *frame,
+    struct aws_byte_cursor data,
+    void *user_data);
+
+struct secure_tunneling_test_context {
+    enum aws_secure_tunneling_local_proxy_mode local_proxy_mode;
+    struct aws_secure_tunnel *secure_tunnel;
+};
+static struct secure_tunneling_test_context s_test_context = {0};
+
+static bool s_on_stream_start_called = false;
+static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel) {
+    s_on_stream_start_called = true;
+}
+
+static void s_init_secure_tunneling_connection_config(
+    struct aws_allocator *allocator,
+    struct aws_client_bootstrap *bootstrap,
+    struct aws_socket_options *socket_options,
+    const char *access_token,
+    enum aws_secure_tunneling_local_proxy_mode local_proxy_mode,
+    const char *endpoint,
+    struct aws_secure_tunneling_connection_config *config) {
+
+    AWS_ZERO_STRUCT(*config);
+    config->allocator = allocator;
+    config->bootstrap = bootstrap;
+    config->socket_options = socket_options;
+
+    config->access_token = aws_byte_cursor_from_c_str(access_token);
+    config->local_proxy_mode = local_proxy_mode;
+    config->endpoint_host = aws_byte_cursor_from_c_str(endpoint);
+
+    config->on_stream_start = s_on_stream_start;
+    /* TODO: Initialize the rest of the callbacks */
+}
+
+static int before(struct aws_allocator *allocator, void *ctx) {
+    struct secure_tunneling_test_context *test_context = ctx;
+
+    aws_http_library_init(allocator);
+    aws_iotdevice_library_init(allocator);
+
+    struct aws_secure_tunneling_connection_config config;
+    s_init_secure_tunneling_connection_config(
+        allocator, NULL, NULL, ACCESS_TOKEN, test_context->local_proxy_mode, ENDPOINT, &config);
+
+    test_context->secure_tunnel = aws_secure_tunnel_new(&config);
+
+    return AWS_OP_SUCCESS;
+}
+
+static int after(struct aws_allocator *allocator, int setup_result, void *ctx) {
+    struct secure_tunneling_test_context *test_context = ctx;
+
+    aws_secure_tunnel_release(test_context->secure_tunnel);
+    aws_iotdevice_library_clean_up();
+    aws_http_library_clean_up();
+
+    return AWS_OP_SUCCESS;
+}
+
+static void s_send_secure_tunneling_frame_to_websocket(
+    const struct aws_iot_st_msg *st_msg,
+    struct aws_allocator *allocator,
+    struct aws_secure_tunnel *secure_tunnel) {
+
+    struct aws_byte_buf serialized_st_msg;
+    aws_iot_st_msg_serialize_from_struct(&serialized_st_msg, allocator, *st_msg);
+
+    /* Prepend 2 bytes length */
+    struct aws_byte_buf websocket_frame;
+    aws_byte_buf_init(&websocket_frame, allocator, serialized_st_msg.len + 2);
+    aws_byte_buf_write_be16(&websocket_frame, serialized_st_msg.len);
+    struct aws_byte_cursor c = aws_byte_cursor_from_buf(&serialized_st_msg);
+    aws_byte_buf_append(&websocket_frame, &c);
+    c = aws_byte_cursor_from_buf(&websocket_frame);
+
+    on_websocket_incoming_frame_payload(NULL, NULL, c, secure_tunnel);
+
+    aws_byte_buf_clean_up(&serialized_st_msg);
+    aws_byte_buf_clean_up(&websocket_frame);
+}
+
+AWS_TEST_CASE_FIXTURE(
+    secure_tunneling_handle_stream_start_test,
+    before,
+    s_secure_tunneling_handle_stream_start_test,
+    after,
+    &s_test_context);
+static int s_secure_tunneling_handle_stream_start_test(struct aws_allocator *allocator, void *ctx) {
+    const int32_t expected_stream_id = 10;
+
+    struct secure_tunneling_test_context *test_context = ctx;
+    test_context->secure_tunnel->config.local_proxy_mode = AWS_SECURE_TUNNELING_DESTINATION_MODE;
+
+    s_on_stream_start_called = false;
+
+    struct aws_iot_st_msg st_msg;
+    AWS_ZERO_STRUCT(st_msg);
+    st_msg.type = STREAM_START;
+    st_msg.streamId = expected_stream_id;
+    s_send_secure_tunneling_frame_to_websocket(&st_msg, allocator, test_context->secure_tunnel);
+
+    ASSERT_TRUE(s_on_stream_start_called);
+    ASSERT_INT_EQUALS(expected_stream_id, test_context->secure_tunnel->stream_id);
+
+    return AWS_OP_SUCCESS;
+}

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -8,6 +8,8 @@
 #include <aws/iotdevice/secure_tunneling.h>
 #include <aws/testing/aws_test_harness.h>
 
+#define UNUSED(x) (void)(x)
+
 #define ACCESS_TOKEN "access_token"
 #define ENDPOINT "data.tunneling.iot.us-west-2.amazonaws.com"
 
@@ -27,6 +29,7 @@ static struct secure_tunneling_test_context s_test_context = {0};
 
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel) {
+    UNUSED(secure_tunnel);
     s_on_stream_start_called = true;
 }
 
@@ -68,6 +71,9 @@ static int before(struct aws_allocator *allocator, void *ctx) {
 }
 
 static int after(struct aws_allocator *allocator, int setup_result, void *ctx) {
+    UNUSED(allocator);
+    UNUSED(setup_result);
+
     struct secure_tunneling_test_context *test_context = ctx;
 
     aws_secure_tunnel_release(test_context->secure_tunnel);
@@ -88,7 +94,7 @@ static void s_send_secure_tunneling_frame_to_websocket(
     /* Prepend 2 bytes length */
     struct aws_byte_buf websocket_frame;
     aws_byte_buf_init(&websocket_frame, allocator, serialized_st_msg.len + 2);
-    aws_byte_buf_write_be16(&websocket_frame, serialized_st_msg.len);
+    aws_byte_buf_write_be16(&websocket_frame, (uint16_t)serialized_st_msg.len);
     struct aws_byte_cursor c = aws_byte_cursor_from_buf(&serialized_st_msg);
     aws_byte_buf_append(&websocket_frame, &c);
     c = aws_byte_cursor_from_buf(&websocket_frame);


### PR DESCRIPTION
Test added:
* secure_tunneling_handle_stream_start_test

I just wanted to add one test first to make sure I am using the test framework correctly. The rest of the tests that test handling of received data would be similar. 

Test result:
```
/home/ubuntu/CLionProjects/aws-c-iot/cmake-build-debug-remote/tests/aws-c-iot-tests
Available tests:
  0. devicedefender_task_unsupported_report_format
  1. devicedefender_get_system_network_total
  2. devicedefender_get_network_connections
  3. devicedefender_success_test
  4. secure_tunneling_handle_stream_start_test
To run a test, enter the test number: 4
4
[INFO] [2020-10-21T04:51:28Z] [00007ff5e51acc40] [tls-handler] - static: Initializing TLS using s2n.
[DEBUG] [2020-10-21T04:51:28Z] [00007ff5e51acc40] [tls-handler] - ctx: Based on OS, we detected the default PKI path as /etc/ssl/certs, and ca file as /etc/ssl/certs/ca-certificates.crt
[WARN] [2020-10-21T04:51:28Z] [00007ff5e51acc40] [tls-handler] - ctx: X.509 validation has been disabled. If this is not running in a test environment, this is likely a security vulnerability.
[INFO] [2020-10-21T04:51:28Z] [00007ff5e51acc40] [iotdevice-st] - Received StreamStart in destination mode. stream_id=10
secure_tunneling_handle_stream_start_test [ OK ]

Process finished with exit code 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
