### PR TITLE
Add more unit tests for secure tunneling

### DIFF
--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -200,7 +200,7 @@ static const char *s_get_proxy_mode_string(enum aws_secure_tunneling_local_proxy
     return "destination";
 }
 
-static struct aws_http_message *s_new_handshake_request(const struct aws_secure_tunnel *secure_tunnel) {
+struct aws_http_message *new_handshake_request(const struct aws_secure_tunnel *secure_tunnel) {
     char path[50];
     snprintf(
         path,
@@ -238,7 +238,7 @@ static void s_init_websocket_client_connection_options(
     websocket_options->tls_options = &secure_tunnel->tls_con_opt;
     websocket_options->host = secure_tunnel->config.endpoint_host;
     websocket_options->port = 443;
-    websocket_options->handshake_request = s_new_handshake_request(secure_tunnel);
+    websocket_options->handshake_request = new_handshake_request(secure_tunnel);
     websocket_options->initial_window_size = MAX_WEBSOCKET_PAYLOAD; /* TODO: followup */
     websocket_options->user_data = secure_tunnel;
     websocket_options->on_connection_setup = s_on_websocket_setup;

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -200,7 +200,7 @@ static const char *s_get_proxy_mode_string(enum aws_secure_tunneling_local_proxy
     return "destination";
 }
 
-struct aws_http_message *new_handshake_request(const struct aws_secure_tunnel *secure_tunnel) {
+static struct aws_http_message *s_new_handshake_request(const struct aws_secure_tunnel *secure_tunnel) {
     char path[50];
     snprintf(
         path,
@@ -227,7 +227,7 @@ struct aws_http_message *new_handshake_request(const struct aws_secure_tunnel *s
     return handshake_request;
 }
 
-static void s_init_websocket_client_connection_options(
+void init_websocket_client_connection_options(
     struct aws_secure_tunnel *secure_tunnel,
     struct aws_websocket_client_connection_options *websocket_options) {
 
@@ -238,7 +238,7 @@ static void s_init_websocket_client_connection_options(
     websocket_options->tls_options = &secure_tunnel->tls_con_opt;
     websocket_options->host = secure_tunnel->config.endpoint_host;
     websocket_options->port = 443;
-    websocket_options->handshake_request = new_handshake_request(secure_tunnel);
+    websocket_options->handshake_request = s_new_handshake_request(secure_tunnel);
     websocket_options->initial_window_size = MAX_WEBSOCKET_PAYLOAD; /* TODO: followup */
     websocket_options->user_data = secure_tunnel;
     websocket_options->on_connection_setup = s_on_websocket_setup;
@@ -258,7 +258,7 @@ static int s_secure_tunneling_connect(struct aws_secure_tunnel *secure_tunnel) {
     }
 
     struct aws_websocket_client_connection_options websocket_options;
-    s_init_websocket_client_connection_options(secure_tunnel, &websocket_options);
+    init_websocket_client_connection_options(secure_tunnel, &websocket_options);
     if (aws_websocket_client_connect(&websocket_options)) {
         return AWS_OP_ERR;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(secure_tunneling_handle_data_receive_test)
     add_test_case(secure_tunneling_handle_stream_reset_test)
     add_test_case(secure_tunneling_handle_session_reset_test)
-    add_test_case(secure_tunneling_new_handshake_request_test)
+    add_test_case(secure_tunneling_init_websocket_options_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(devicedefender_get_network_connections)
     add_test_case(devicedefender_success_test)
     add_test_case(secure_tunneling_handle_stream_start_test)
+    add_test_case(secure_tunneling_handle_data_receive_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(secure_tunneling_handle_stream_start_test)
     add_test_case(secure_tunneling_handle_data_receive_test)
     add_test_case(secure_tunneling_handle_stream_reset_test)
+    add_test_case(secure_tunneling_handle_session_reset_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(devicedefender_success_test)
     add_test_case(secure_tunneling_handle_stream_start_test)
     add_test_case(secure_tunneling_handle_data_receive_test)
+    add_test_case(secure_tunneling_handle_stream_reset_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ if (UNIX AND NOT APPLE)
     add_test_case(secure_tunneling_handle_data_receive_test)
     add_test_case(secure_tunneling_handle_stream_reset_test)
     add_test_case(secure_tunneling_handle_session_reset_test)
+    add_test_case(secure_tunneling_new_handshake_request_test)
 endif()
 
 generate_test_driver(${PROJECT_NAME}-tests)

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -1,5 +1,7 @@
+#include <aws/common/string.h>
 #include <aws/common/zero.h>
 #include <aws/http/http.h>
+#include <aws/http/request_response.h>
 #include <aws/io/channel_bootstrap.h>
 #include <aws/io/event_loop.h>
 #include <aws/io/socket.h>
@@ -12,17 +14,23 @@
 
 #define INVALID_STREAM_ID 0
 #define STREAM_ID 10
-#define ACCESS_TOKEN "access_token"
+#define ACCESS_TOKEN "my_super_secret_access_token"
 #define ENDPOINT "data.tunneling.iot.us-west-2.amazonaws.com"
 #define PAYLOAD "secure tunneling data payload"
 
-/* Callback when websocket gets data. The tests here are calling this function directly. */
+/*
+ * The tests here call these functions directly.
+ */
+
+/* Callback when websocket gets data */
 struct aws_websocket_incoming_frame;
 extern bool on_websocket_incoming_frame_payload(
     struct aws_websocket *websocket,
     const struct aws_websocket_incoming_frame *frame,
     struct aws_byte_cursor data,
     void *user_data);
+/* Function that returns a websocket upgrade handshake request */
+extern struct aws_http_message *new_handshake_request(const struct aws_secure_tunnel *secure_tunnel);
 
 struct secure_tunneling_test_context {
     enum aws_secure_tunneling_local_proxy_mode local_proxy_mode;
@@ -244,5 +252,47 @@ static int s_secure_tunneling_handle_session_reset_test(struct aws_allocator *al
     ASSERT_INT_EQUALS(INVALID_STREAM_ID, test_context->secure_tunnel->stream_id);
     ASSERT_UINT_EQUALS(0, test_context->secure_tunnel->received_data.len);
 
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE_FIXTURE(
+    secure_tunneling_new_handshake_request_test,
+    before,
+    s_secure_tunneling_new_handshake_request_test,
+    after,
+    &s_test_context);
+static int s_secure_tunneling_new_handshake_request_test(struct aws_allocator *allocator, void *ctx) {
+    UNUSED(allocator);
+
+    struct secure_tunneling_test_context *test_context = ctx;
+
+    /* Create the handshake request */
+    struct aws_http_message *handshake_request = new_handshake_request(test_context->secure_tunnel);
+
+    ASSERT_TRUE(aws_http_message_is_request(handshake_request));
+
+    struct aws_byte_cursor method;
+    aws_http_message_get_request_method(handshake_request, &method);
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&method, "GET"));
+
+    /* Verify path */
+    struct aws_byte_cursor path;
+    aws_http_message_get_request_path(handshake_request, &path);
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&path, "/tunnel?local-proxy-mode=source"));
+
+    /* Verify headers */
+    const char *expected_headers[][2] = {
+        {"Sec-WebSocket-Protocol", "aws.iot.securetunneling-1.0"},
+        {"access-token", ACCESS_TOKEN}
+    };
+    const struct aws_http_headers *headers = aws_http_message_get_const_headers(handshake_request);
+    for (size_t i = 0; i < sizeof(expected_headers)/sizeof(expected_headers[0]); i++) {
+        struct aws_byte_cursor name = aws_byte_cursor_from_c_str(expected_headers[i][0]);
+        struct aws_byte_cursor value;
+        ASSERT_INT_EQUALS(AWS_OP_SUCCESS, aws_http_headers_get(headers, name, &value));
+        ASSERT_TRUE(aws_byte_cursor_eq_c_str(&value, expected_headers[i][1]));
+    }
+
+    aws_http_message_release(handshake_request);
     return AWS_OP_SUCCESS;
 }

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -40,6 +40,12 @@ static void s_on_data_receive(const struct aws_secure_tunnel *secure_tunnel, con
     s_on_data_receive_correct_payload = aws_byte_buf_eq_c_str(data, PAYLOAD);
 }
 
+static bool s_on_stream_reset_called = false;
+static void s_on_stream_reset(const struct aws_secure_tunnel *secure_tunnel) {
+    UNUSED(secure_tunnel);
+    s_on_stream_reset_called = true;
+}
+
 static void s_init_secure_tunneling_connection_config(
     struct aws_allocator *allocator,
     struct aws_client_bootstrap *bootstrap,
@@ -60,6 +66,7 @@ static void s_init_secure_tunneling_connection_config(
 
     config->on_stream_start = s_on_stream_start;
     config->on_data_receive = s_on_data_receive;
+    config->on_stream_reset = s_on_stream_reset;
     /* TODO: Initialize the rest of the callbacks */
 }
 
@@ -155,6 +162,37 @@ static int s_secure_tunneling_handle_data_receive_test(struct aws_allocator *all
     s_on_data_receive_correct_payload = false;
     s_send_secure_tunneling_frame_to_websocket(&st_msg, allocator, test_context->secure_tunnel);
     ASSERT_TRUE(s_on_data_receive_correct_payload);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE_FIXTURE(
+    secure_tunneling_handle_stream_reset_test,
+    before,
+    s_secure_tunneling_handle_stream_reset_test,
+    after,
+    &s_test_context);
+static int s_secure_tunneling_handle_stream_reset_test(struct aws_allocator *allocator, void *ctx) {
+    const int32_t expected_stream_id = 10;
+
+    struct secure_tunneling_test_context *test_context = ctx;
+    test_context->secure_tunnel->config.local_proxy_mode = AWS_SECURE_TUNNELING_DESTINATION_MODE;
+
+    /* Send StreamStart first */
+    struct aws_iot_st_msg st_msg;
+    AWS_ZERO_STRUCT(st_msg);
+    st_msg.type = STREAM_START;
+    st_msg.streamId = expected_stream_id;
+    s_send_secure_tunneling_frame_to_websocket(&st_msg, allocator, test_context->secure_tunnel);
+
+    /* Send StreamReset */
+    AWS_ZERO_STRUCT(st_msg);
+    st_msg.type = STREAM_RESET;
+    st_msg.streamId = expected_stream_id;
+    s_on_stream_reset_called = false;
+    s_send_secure_tunneling_frame_to_websocket(&st_msg, allocator, test_context->secure_tunnel);
+
+    ASSERT_TRUE(s_on_stream_reset_called);
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
Added the following unit tests:
- secure_tunneling_handle_data_receive_test
- secure_tunneling_handle_stream_reset_test
- secure_tunneling_handle_session_reset_test
- secure_tunneling_init_websocket_options_test

Testing done:
Ran test 4-8. All passed. For example: 
```
/home/ubuntu/CLionProjects/aws-c-iot/cmake-build-debug-remote/tests/aws-c-iot-tests
Available tests:
  0. devicedefender_task_unsupported_report_format
  1. devicedefender_get_system_network_total
  2. devicedefender_get_network_connections
  3. devicedefender_success_test
  4. secure_tunneling_handle_stream_start_test
  5. secure_tunneling_handle_data_receive_test
  6. secure_tunneling_handle_stream_reset_test
  7. secure_tunneling_handle_session_reset_test
  8. secure_tunneling_init_websocket_options_test
To run a test, enter the test number: 8
8
[INFO] [2020-10-22T16:41:18Z] [00007f00d22a6c40] [tls-handler] - static: Initializing TLS using s2n.
[DEBUG] [2020-10-22T16:41:18Z] [00007f00d22a6c40] [tls-handler] - ctx: Based on OS, we detected the default PKI path as /etc/ssl/certs, and ca file as /etc/ssl/certs/ca-certificates.crt
[WARN] [2020-10-22T16:41:18Z] [00007f00d22a6c40] [tls-handler] - ctx: X.509 validation has been disabled. If this is not running in a test environment, this is likely a security vulnerability.
secure_tunneling_init_websocket_options_test [ OK ]

Process finished with exit code 0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.