### PR TITLE
`close` is a synchronize function

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -58,7 +58,6 @@ struct aws_secure_tunneling_connection_config {
     aws_secure_tunneling_on_stream_start_fn *on_stream_start;
     aws_secure_tunneling_on_stream_reset_fn *on_stream_reset;
     aws_secure_tunneling_on_session_reset_fn *on_session_reset;
-    aws_secure_tunneling_on_close_fn *on_close;
 };
 
 struct aws_secure_tunnel {

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -425,7 +425,6 @@ static void s_copy_secure_tunneling_connection_config(
     dest->on_stream_start = src->on_stream_start;
     dest->on_stream_reset = src->on_stream_reset;
     dest->on_session_reset = src->on_session_reset;
-    dest->on_close = src->on_close;
 }
 
 struct aws_secure_tunnel *aws_secure_tunnel_new(


### PR DESCRIPTION
There is no callback when `close` is completed.

For reference, please see the discussion in a previous PR.
https://github.com/awslabs/aws-c-iot/pull/11

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
