### PR TITLE
Add user_data to Secure Tunneling callbacks

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -25,15 +25,16 @@ typedef int(aws_secure_tunneling_send_stream_reset_fn)(struct aws_secure_tunnel 
 typedef int(aws_secure_tunneling_close_fn)(struct aws_secure_tunnel *secure_tunnel);
 
 /* Callbacks */
-typedef void(aws_secure_tunneling_on_connection_complete_fn)(const struct aws_secure_tunnel *secure_tunnel);
+typedef void(
+    aws_secure_tunneling_on_connection_complete_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
 typedef void(aws_secure_tunneling_on_send_data_complete_fn)(int error_code, void *user_data);
 typedef void(aws_secure_tunneling_on_data_receive_fn)(
     const struct aws_secure_tunnel *secure_tunnel,
-    const struct aws_byte_buf *data);
-typedef void(aws_secure_tunneling_on_stream_start_fn)(const struct aws_secure_tunnel *secure_tunnel);
-typedef void(aws_secure_tunneling_on_stream_reset_fn)(const struct aws_secure_tunnel *secure_tunnel);
-typedef void(aws_secure_tunneling_on_session_reset_fn)(const struct aws_secure_tunnel *secure_tunnel);
-typedef void(aws_secure_tunneling_on_close_fn)(const struct aws_secure_tunnel *secure_tunnel, uint16_t close_code);
+    const struct aws_byte_buf *data,
+    void *user_data);
+typedef void(aws_secure_tunneling_on_stream_start_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
+typedef void(aws_secure_tunneling_on_stream_reset_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
+typedef void(aws_secure_tunneling_on_session_reset_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
 
 struct aws_secure_tunnel_vtable {
     aws_secure_tunneling_connect_fn *connect;
@@ -58,6 +59,8 @@ struct aws_secure_tunneling_connection_config {
     aws_secure_tunneling_on_stream_start_fn *on_stream_start;
     aws_secure_tunneling_on_stream_reset_fn *on_stream_reset;
     aws_secure_tunneling_on_session_reset_fn *on_session_reset;
+
+    void *user_data;
 };
 
 struct aws_secure_tunnel {

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -25,16 +25,12 @@ typedef int(aws_secure_tunneling_send_stream_reset_fn)(struct aws_secure_tunnel 
 typedef int(aws_secure_tunneling_close_fn)(struct aws_secure_tunnel *secure_tunnel);
 
 /* Callbacks */
-typedef void(
-    aws_secure_tunneling_on_connection_complete_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
+typedef void(aws_secure_tunneling_on_connection_complete_fn)(void *user_data);
 typedef void(aws_secure_tunneling_on_send_data_complete_fn)(int error_code, void *user_data);
-typedef void(aws_secure_tunneling_on_data_receive_fn)(
-    const struct aws_secure_tunnel *secure_tunnel,
-    const struct aws_byte_buf *data,
-    void *user_data);
-typedef void(aws_secure_tunneling_on_stream_start_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
-typedef void(aws_secure_tunneling_on_stream_reset_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
-typedef void(aws_secure_tunneling_on_session_reset_fn)(const struct aws_secure_tunnel *secure_tunnel, void *user_data);
+typedef void(aws_secure_tunneling_on_data_receive_fn)(const struct aws_byte_buf *data, void *user_data);
+typedef void(aws_secure_tunneling_on_stream_start_fn)(int32_t stream_id, void *user_data);
+typedef void(aws_secure_tunneling_on_stream_reset_fn)(void *user_data);
+typedef void(aws_secure_tunneling_on_session_reset_fn)(void *user_data);
 
 struct aws_secure_tunnel_vtable {
     aws_secure_tunneling_connect_fn *connect;

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -28,7 +28,7 @@ typedef int(aws_secure_tunneling_close_fn)(struct aws_secure_tunnel *secure_tunn
 typedef void(aws_secure_tunneling_on_connection_complete_fn)(void *user_data);
 typedef void(aws_secure_tunneling_on_send_data_complete_fn)(int error_code, void *user_data);
 typedef void(aws_secure_tunneling_on_data_receive_fn)(const struct aws_byte_buf *data, void *user_data);
-typedef void(aws_secure_tunneling_on_stream_start_fn)(int32_t stream_id, void *user_data);
+typedef void(aws_secure_tunneling_on_stream_start_fn)(void *user_data);
 typedef void(aws_secure_tunneling_on_stream_reset_fn)(void *user_data);
 typedef void(aws_secure_tunneling_on_session_reset_fn)(void *user_data);
 

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -68,7 +68,7 @@ static void s_handle_stream_start(struct aws_secure_tunnel *secure_tunnel, struc
             "Received StreamStart in destination mode. stream_id=%d",
             st_msg->stream_id);
         secure_tunnel->stream_id = st_msg->stream_id;
-        secure_tunnel->config.on_stream_start(st_msg->stream_id, secure_tunnel->config.user_data);
+        secure_tunnel->config.on_stream_start(secure_tunnel->config.user_data);
     }
 }
 

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -37,7 +37,7 @@ static void s_on_websocket_setup(
 
     secure_tunnel->stream_id++;
     secure_tunnel->websocket = websocket;
-    secure_tunnel->config.on_connection_complete(secure_tunnel, secure_tunnel->config.user_data);
+    secure_tunnel->config.on_connection_complete(secure_tunnel->config.user_data);
 }
 
 static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_code, void *user_data) {
@@ -68,7 +68,7 @@ static void s_handle_stream_start(struct aws_secure_tunnel *secure_tunnel, struc
             "Received StreamStart in destination mode. stream_id=%d",
             st_msg->stream_id);
         secure_tunnel->stream_id = st_msg->stream_id;
-        secure_tunnel->config.on_stream_start(secure_tunnel, secure_tunnel->config.user_data);
+        secure_tunnel->config.on_stream_start(st_msg->stream_id, secure_tunnel->config.user_data);
     }
 }
 
@@ -88,7 +88,7 @@ static void s_handle_stream_reset(struct aws_secure_tunnel *secure_tunnel, struc
         return;
     }
 
-    secure_tunnel->config.on_stream_reset(secure_tunnel, secure_tunnel->config.user_data);
+    secure_tunnel->config.on_stream_reset(secure_tunnel->config.user_data);
     s_reset_secure_tunnel(secure_tunnel);
 }
 
@@ -97,7 +97,7 @@ static void s_handle_session_reset(struct aws_secure_tunnel *secure_tunnel) {
         return;
     }
 
-    secure_tunnel->config.on_session_reset(secure_tunnel, secure_tunnel->config.user_data);
+    secure_tunnel->config.on_session_reset(secure_tunnel->config.user_data);
     s_reset_secure_tunnel(secure_tunnel);
 }
 
@@ -106,7 +106,7 @@ static void s_process_iot_st_msg(struct aws_secure_tunnel *secure_tunnel, struct
 
     switch (st_msg->type) {
         case DATA:
-            secure_tunnel->config.on_data_receive(secure_tunnel, &st_msg->payload, secure_tunnel->config.user_data);
+            secure_tunnel->config.on_data_receive(&st_msg->payload, secure_tunnel->config.user_data);
             break;
         case STREAM_START:
             s_handle_stream_start(secure_tunnel, st_msg);

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -45,9 +45,9 @@ static void s_on_data_receive(const struct aws_byte_buf *data, void *user_data) 
     aws_byte_buf_clean_up(&data_to_print);
 }
 
-static void s_on_stream_start(int32_t stream_id, void *user_data) {
+static void s_on_stream_start(void *user_data) {
     UNUSED(user_data);
-    AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received StreamStart. stream_id=%d", stream_id);
+    AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received StreamStart.");
 }
 
 static void s_on_stream_reset(void *user_data) {

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -23,19 +23,21 @@ static void s_on_send_data_complete(int error_code, void *user_data) {
     aws_mutex_unlock(&mutex);
 }
 
-static void s_on_connection_complete(const struct aws_secure_tunnel *secure_tunnel) {
-    UNUSED(secure_tunnel);
+static void s_on_connection_complete(void *user_data) {
+    UNUSED(user_data);
     aws_mutex_lock(&mutex);
     aws_condition_variable_notify_one(&condition_variable);
     aws_mutex_unlock(&mutex);
 }
 
-static void s_on_data_receive(const struct aws_secure_tunnel *secure_tunnel, const struct aws_byte_buf *data) {
+static void s_on_data_receive(const struct aws_byte_buf *data, void *user_data) {
     AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received data:");
+
+    struct aws_allocator *allocator = (struct aws_allocator *)user_data;
 
     struct aws_byte_cursor data_cursor = aws_byte_cursor_from_buf(data);
     struct aws_byte_buf data_to_print;
-    aws_byte_buf_init(&data_to_print, secure_tunnel->config.allocator, data->len + 1); /* +1 for null terminator */
+    aws_byte_buf_init(&data_to_print, allocator, data->len + 1); /* +1 for null terminator */
     aws_byte_buf_append(&data_to_print, &data_cursor);
     aws_byte_buf_append_null_terminator(&data_to_print);
     AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "%s", (char *)data_to_print.buffer);
@@ -43,18 +45,18 @@ static void s_on_data_receive(const struct aws_secure_tunnel *secure_tunnel, con
     aws_byte_buf_clean_up(&data_to_print);
 }
 
-static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel) {
-    AWS_LOGF_INFO(
-        AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received StreamStart. stream_id=%d", secure_tunnel->stream_id);
+static void s_on_stream_start(int32_t stream_id, void *user_data) {
+    UNUSED(user_data);
+    AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received StreamStart. stream_id=%d", stream_id);
 }
 
-static void s_on_stream_reset(const struct aws_secure_tunnel *secure_tunnel) {
-    UNUSED(secure_tunnel);
+static void s_on_stream_reset(void *user_data) {
+    UNUSED(user_data);
     AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received StreamReset.");
 }
 
-static void s_on_session_reset(const struct aws_secure_tunnel *secure_tunnel) {
-    UNUSED(secure_tunnel);
+static void s_on_session_reset(void *user_data) {
+    UNUSED(user_data);
     AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received SessionReset.");
 }
 
@@ -89,7 +91,8 @@ static void s_init_secure_tunneling_connection_config(
     config->on_stream_start = s_on_stream_start;
     config->on_stream_reset = s_on_stream_reset;
     config->on_session_reset = s_on_session_reset;
-    /* TODO: Initialize the rest of the callbacks */
+
+    config->user_data = allocator;
 }
 
 int main(int argc, char **argv) {

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -53,26 +53,33 @@ struct secure_tunneling_test_context {
 static struct secure_tunneling_test_context s_test_context = {0};
 
 static bool s_on_stream_start_called = false;
-static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel) {
+static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
     UNUSED(secure_tunnel);
+    UNUSED(user_data);
     s_on_stream_start_called = true;
 }
 
 static bool s_on_data_receive_correct_payload = false;
-static void s_on_data_receive(const struct aws_secure_tunnel *secure_tunnel, const struct aws_byte_buf *data) {
+static void s_on_data_receive(
+    const struct aws_secure_tunnel *secure_tunnel,
+    const struct aws_byte_buf *data,
+    void *user_data) {
     UNUSED(secure_tunnel);
+    UNUSED(user_data);
     s_on_data_receive_correct_payload = aws_byte_buf_eq_c_str(data, PAYLOAD);
 }
 
 static bool s_on_stream_reset_called = false;
-static void s_on_stream_reset(const struct aws_secure_tunnel *secure_tunnel) {
+static void s_on_stream_reset(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
     UNUSED(secure_tunnel);
+    UNUSED(user_data);
     s_on_stream_reset_called = true;
 }
 
 static bool s_on_session_reset_called = false;
-static void s_on_session_reset(const struct aws_secure_tunnel *secure_tunnel) {
+static void s_on_session_reset(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
     UNUSED(secure_tunnel);
+    UNUSED(user_data);
     s_on_session_reset_called = true;
 }
 
@@ -348,8 +355,8 @@ static int s_secure_tunneling_init_websocket_options_test(struct aws_allocator *
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&path, "/tunnel?local-proxy-mode=source"));
 
     /* Verify headers */
-    const char *expected_headers[][2] = {{"Sec-WebSocket-Protocol", "aws.iot.securetunneling-1.0"},
-                                         {"access-token", ACCESS_TOKEN}};
+    const char *expected_headers[][2] = {
+        {"Sec-WebSocket-Protocol", "aws.iot.securetunneling-1.0"}, {"access-token", ACCESS_TOKEN}};
     const struct aws_http_headers *headers = aws_http_message_get_const_headers(websocket_options.handshake_request);
     for (size_t i = 0; i < sizeof(expected_headers) / sizeof(expected_headers[0]); i++) {
         struct aws_byte_cursor name = aws_byte_cursor_from_c_str(expected_headers[i][0]);

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -34,13 +34,11 @@ extern bool on_websocket_incoming_frame_payload(
 extern void init_websocket_client_connection_options(
     struct aws_secure_tunnel *secure_tunnel,
     struct aws_websocket_client_connection_options *websocket_options);
-
 extern int secure_tunneling_init_send_frame(
     struct aws_websocket_send_frame_options *frame_options,
     struct aws_secure_tunnel *secure_tunnel,
     const struct aws_byte_cursor *data,
     enum aws_iot_st_message_type type);
-
 extern bool secure_tunneling_send_data_call(
     struct aws_websocket *websocket,
     struct aws_byte_buf *out_buf,
@@ -53,8 +51,7 @@ struct secure_tunneling_test_context {
 static struct secure_tunneling_test_context s_test_context = {0};
 
 static bool s_on_stream_start_called = false;
-static void s_on_stream_start(int32_t stream_id, void *user_data) {
-    UNUSED(stream_id);
+static void s_on_stream_start(void *user_data) {
     UNUSED(user_data);
     s_on_stream_start_called = true;
 }

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -53,32 +53,26 @@ struct secure_tunneling_test_context {
 static struct secure_tunneling_test_context s_test_context = {0};
 
 static bool s_on_stream_start_called = false;
-static void s_on_stream_start(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
-    UNUSED(secure_tunnel);
+static void s_on_stream_start(int32_t stream_id, void *user_data) {
+    UNUSED(stream_id);
     UNUSED(user_data);
     s_on_stream_start_called = true;
 }
 
 static bool s_on_data_receive_correct_payload = false;
-static void s_on_data_receive(
-    const struct aws_secure_tunnel *secure_tunnel,
-    const struct aws_byte_buf *data,
-    void *user_data) {
-    UNUSED(secure_tunnel);
+static void s_on_data_receive(const struct aws_byte_buf *data, void *user_data) {
     UNUSED(user_data);
     s_on_data_receive_correct_payload = aws_byte_buf_eq_c_str(data, PAYLOAD);
 }
 
 static bool s_on_stream_reset_called = false;
-static void s_on_stream_reset(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
-    UNUSED(secure_tunnel);
+static void s_on_stream_reset(void *user_data) {
     UNUSED(user_data);
     s_on_stream_reset_called = true;
 }
 
 static bool s_on_session_reset_called = false;
-static void s_on_session_reset(const struct aws_secure_tunnel *secure_tunnel, void *user_data) {
-    UNUSED(secure_tunnel);
+static void s_on_session_reset(void *user_data) {
     UNUSED(user_data);
     s_on_session_reset_called = true;
 }
@@ -355,8 +349,8 @@ static int s_secure_tunneling_init_websocket_options_test(struct aws_allocator *
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&path, "/tunnel?local-proxy-mode=source"));
 
     /* Verify headers */
-    const char *expected_headers[][2] = {
-        {"Sec-WebSocket-Protocol", "aws.iot.securetunneling-1.0"}, {"access-token", ACCESS_TOKEN}};
+    const char *expected_headers[][2] = {{"Sec-WebSocket-Protocol", "aws.iot.securetunneling-1.0"},
+                                         {"access-token", ACCESS_TOKEN}};
     const struct aws_http_headers *headers = aws_http_message_get_const_headers(websocket_options.handshake_request);
     for (size_t i = 0; i < sizeof(expected_headers) / sizeof(expected_headers[0]); i++) {
         struct aws_byte_cursor name = aws_byte_cursor_from_c_str(expected_headers[i][0]);


### PR DESCRIPTION
When writing the C++ wrapper for secure tunneling, I need to access the C++ `SecureTunnel` object from C callbacks. Adding `user_data` (which is a common pattern in the SDK code) to the C callbacks to supply the C++ `SecureTunnel` object.

Also clean up the callback NOT to supply the C `aws_secure_tunnel` pointer and only provide the necessary information. Supplying `aws_secure_tunnel` pointer to the client callbacks exposes "private" data to the client.

To see how `user_data` is being used in the C++ wrapper, please see this [PR](https://github.com/awslabs/aws-crt-cpp/pull/195).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
