### PR TITLE
Updating the link of where to find the s2n commit hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library is licensed under the Apache 2.0 License.
 
 #### Building s2n (Linux Only)
 
-If you are building on Linux, you will need to build s2n before being able to build aws-c-io, which is a dependency of aws-c-auth.  For our CRT's, we build s2n at a specific commit, and recommend doing the same when using it with this library.  That commit hash can be found [here](https://github.com/awslabs/aws-crt-cpp/tree/master/aws-common-runtime).  The commands below will build s2n using OpenSSL 1.1.1.  For using other versions of OpenSSL, there is additional information in the [s2n Usage Guide](https://github.com/awslabs/s2n/blob/master/docs/USAGE-GUIDE.md).
+If you are building on Linux, you will need to build s2n before being able to build aws-c-io, which is a dependency of aws-c-auth.  For our CRT's, we build s2n at a specific commit, and recommend doing the same when using it with this library.  That commit hash can be found [here](https://github.com/awslabs/aws-crt-cpp/tree/main/crt).  The commands below will build s2n using OpenSSL 1.1.1.  For using other versions of OpenSSL, there is additional information in the [s2n Usage Guide](https://github.com/awslabs/s2n/blob/master/docs/USAGE-GUIDE.md).
 
 ```
 git clone git@github.com:awslabs/s2n.git


### PR DESCRIPTION
*Description of changes:*

* Updated the README link to the aws-crt-cpp repo for finding which s2n commit hash should be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
