### PR TITLE
Advance tmp_cursor as well. Otherwise we are reading from the same spot!

### DIFF
--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -140,6 +140,7 @@ static void s_process_received_data(struct aws_secure_tunnel *secure_tunnel) {
 
         struct aws_byte_cursor st_frame = {.len = data_length, .ptr = cursor.ptr};
         aws_byte_cursor_advance(&cursor, data_length);
+        tmp_cursor = cursor;
 
         struct aws_iot_st_msg st_msg;
         aws_iot_st_msg_deserialize_from_cursor(&st_msg, &st_frame, secure_tunnel->config.allocator);


### PR DESCRIPTION
*Description of changes:*
Before this change, the code that parses the payload uses a `tmp_cursor` to check if the payload is completed. If it does, the code  processes the payload, advances `cursor` and tries to look for another complete payload.

However the code failed to update `tmp_cursor` after updating `cursor`. Therefore, the code reads from the same place again!

This PR addresses this issue by update `tmp_cursor` after updating `cursor`.

I use Device Client for testing. Before this change, I see the same payload is processed 3 times. After this change, one payload is only processed once.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
