### PR TITLE
Send websocket ping every 20 seconds

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -2,10 +2,10 @@
 #define AWS_IOTDEVICE_SECURE_TUNNELING_H
 
 #include <aws/common/byte_buf.h>
+#include <aws/common/task_scheduler.h>
 #include <aws/io/tls_channel_handler.h>
-#include <aws/iotdevice/iotdevice.h>
-
 #include <aws/iotdevice/exports.h>
+#include <aws/iotdevice/iotdevice.h>
 
 enum aws_secure_tunneling_local_proxy_mode { AWS_SECURE_TUNNELING_SOURCE_MODE, AWS_SECURE_TUNNELING_DESTINATION_MODE };
 
@@ -75,6 +75,10 @@ struct aws_secure_tunnel {
 
     /* Stores what has been received but not processed */
     struct aws_byte_buf received_data;
+
+    /* The secure tunneling endpoint ELB drops idle connect after 1 minute. We need to send a ping periodically to keep
+     * the connection */
+    struct aws_task ping_task;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -42,7 +42,7 @@ static void s_ping_task(struct aws_task *task, void *user_data, enum aws_task_st
         aws_event_loop_group_get_next_loop(secure_tunnel->config.bootstrap->event_loop_group);
     uint64_t now;
     aws_event_loop_current_clock_time(event_loop, &now);
-    aws_event_loop_schedule_task_future(event_loop, task, now + 20L * 1000000000);
+    aws_event_loop_schedule_task_future(event_loop, task, now + (uint64_t)20 * 1000000000);
 }
 
 static void s_on_websocket_setup(


### PR DESCRIPTION
*Description of changes:*
Secure Tunneling endpoint ELB drops idle connection after 1 minute. This PR sends a websocket ping to the endpoint every 20 seconds to keep the connection alive.

I tested this by pulling the code into the Device Client project and verified that an idle connection can last for more than 5 minutes. I stopped the test after 5 minutes. Before this change, an idle connection would drop at exactly 1 minute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
