### PR TITLE
Verify peer when connecting to the secure tunneling endpoint

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -48,7 +48,7 @@ struct aws_secure_tunneling_connection_config {
     struct aws_byte_cursor access_token;
     enum aws_secure_tunneling_local_proxy_mode local_proxy_mode;
     struct aws_byte_cursor endpoint_host;
-    const char *ca_file;
+    const char *root_ca;
 
     aws_secure_tunneling_on_connection_complete_fn *on_connection_complete;
     aws_secure_tunneling_on_send_data_complete_fn *on_send_data_complete;

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -48,6 +48,7 @@ struct aws_secure_tunneling_connection_config {
     struct aws_byte_cursor access_token;
     enum aws_secure_tunneling_local_proxy_mode local_proxy_mode;
     struct aws_byte_cursor endpoint_host;
+    const char *ca_file;
 
     aws_secure_tunneling_on_connection_complete_fn *on_connection_complete;
     aws_secure_tunneling_on_send_data_complete_fn *on_send_data_complete;

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -467,10 +467,14 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
     /* tls */
     struct aws_tls_ctx_options tls_ctx_opt;
     aws_tls_ctx_options_init_default_client(&tls_ctx_opt, connection_config->allocator);
-    aws_tls_ctx_options_set_verify_peer(&tls_ctx_opt, false); /* TODO: remove me! */
+    aws_tls_ctx_options_override_default_trust_store_from_path(&tls_ctx_opt, NULL, connection_config->ca_file);
     secure_tunnel->tls_ctx = aws_tls_client_ctx_new(connection_config->allocator, &tls_ctx_opt);
     aws_tls_ctx_options_clean_up(&tls_ctx_opt);
     aws_tls_connection_options_init_from_ctx(&secure_tunnel->tls_con_opt, secure_tunnel->tls_ctx);
+    aws_tls_connection_options_set_server_name(
+        &secure_tunnel->tls_con_opt,
+        connection_config->allocator,
+        (struct aws_byte_cursor *)&connection_config->endpoint_host);
 
     /* Setup vtable here */
     secure_tunnel->vtable.connect = s_secure_tunneling_connect;

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -467,7 +467,7 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
     /* tls */
     struct aws_tls_ctx_options tls_ctx_opt;
     aws_tls_ctx_options_init_default_client(&tls_ctx_opt, connection_config->allocator);
-    aws_tls_ctx_options_override_default_trust_store_from_path(&tls_ctx_opt, NULL, connection_config->ca_file);
+    aws_tls_ctx_options_override_default_trust_store_from_path(&tls_ctx_opt, NULL, connection_config->root_ca);
     secure_tunnel->tls_ctx = aws_tls_client_ctx_new(connection_config->allocator, &tls_ctx_opt);
     aws_tls_ctx_options_clean_up(&tls_ctx_opt);
     aws_tls_connection_options_init_from_ctx(&secure_tunnel->tls_con_opt, secure_tunnel->tls_ctx);

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -85,7 +85,7 @@ static void s_init_secure_tunneling_connection_config(
     config->access_token = aws_byte_cursor_from_c_str(access_token);
     config->local_proxy_mode = local_proxy_mode;
     config->endpoint_host = aws_byte_cursor_from_c_str(endpoint);
-    config->ca_file = root_ca;
+    config->root_ca = root_ca;
 
     config->on_connection_complete = s_on_connection_complete;
     config->on_send_data_complete = s_on_send_data_complete;

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -74,6 +74,7 @@ static void s_init_secure_tunneling_connection_config(
     const char *access_token,
     enum aws_secure_tunneling_local_proxy_mode local_proxy_mode,
     const char *endpoint,
+    const char *root_ca,
     struct aws_secure_tunneling_connection_config *config) {
 
     AWS_ZERO_STRUCT(*config);
@@ -84,6 +85,7 @@ static void s_init_secure_tunneling_connection_config(
     config->access_token = aws_byte_cursor_from_c_str(access_token);
     config->local_proxy_mode = local_proxy_mode;
     config->endpoint_host = aws_byte_cursor_from_c_str(endpoint);
+    config->ca_file = root_ca;
 
     config->on_connection_complete = s_on_connection_complete;
     config->on_send_data_complete = s_on_send_data_complete;
@@ -96,16 +98,17 @@ static void s_init_secure_tunneling_connection_config(
 }
 
 int main(int argc, char **argv) {
-    if (argc < 4) {
+    if (argc < 5) {
         printf(
             "3 args required, only %d passed. Usage:\n"
-            "aws-c-iot-secure_tunneling-client [endpoint] [src|dest] [access_token]\n",
+            "aws-c-iot-secure_tunneling-client [endpoint] [src|dest] [root_ca] [access_token]\n",
             argc - 1);
         return 1;
     }
     const char *endpoint = argv[1];
     enum aws_secure_tunneling_local_proxy_mode local_proxy_mode = s_local_proxy_mode_from_c_str(argv[2]);
-    const char *access_token = argv[3];
+    const char *root_ca = argv[3];
+    const char *access_token = argv[4];
 
     struct aws_allocator *allocator = aws_mem_tracer_new(aws_default_allocator(), NULL, AWS_MEMTRACE_BYTES, 0);
 
@@ -138,12 +141,12 @@ int main(int argc, char **argv) {
     AWS_ZERO_STRUCT(socket_options);
     socket_options.connect_timeout_ms = 3000;
     socket_options.type = AWS_SOCKET_STREAM;
-    socket_options.domain = AWS_SOCKET_IPV6;
+    socket_options.domain = AWS_SOCKET_IPV4;
 
     /* setup secure tunneling connection config */
     struct aws_secure_tunneling_connection_config config;
     s_init_secure_tunneling_connection_config(
-        allocator, bootstrap, &socket_options, access_token, local_proxy_mode, endpoint, &config);
+        allocator, bootstrap, &socket_options, access_token, local_proxy_mode, endpoint, root_ca, &config);
 
     /* Create a secure tunnel object and connect */
     struct aws_secure_tunnel *secure_tunnel = aws_secure_tunnel_new(&config);
@@ -170,8 +173,7 @@ int main(int argc, char **argv) {
 
         AWS_RETURN_ERROR_IF2(aws_secure_tunnel_stream_reset(secure_tunnel) == AWS_OP_SUCCESS, AWS_OP_ERR);
         ASSERT_SUCCESS(aws_condition_variable_wait(&condition_variable, &mutex));
-    }
-    if (local_proxy_mode == AWS_SECURE_TUNNELING_DESTINATION_MODE) {
+    } else if (local_proxy_mode == AWS_SECURE_TUNNELING_DESTINATION_MODE) {
         /* Wait a little for data to show up */
         aws_thread_current_sleep((uint64_t)60 * 60 * 1000000000);
     }


### PR DESCRIPTION
### Description of changes:

* Secure Tunneling config takes the path to a root CA 
* Calls `aws_tls_ctx_options_override_default_trust_store_from_path` with the path to a root CA
* Calls `aws_tls_connection_options_set_server_name` and set the server name. (Reference [here](https://github.com/awslabs/aws-c-io/blob/main/include/aws/io/tls_channel_handler.h#L400-L401))

### Testing done:
* Tested with `aws_iot_secure_tunneling_client_test.c`
* Pull the code into Device Client
* Before this PR, the following warning was in the log. After this PR, there is no such warning.

```
[WARN] [2020-12-18T18:32:47Z] [00007f9a10979c40] [tls-handler] - ctx: X.509 validation has been disabled. If this is not running in a test environment, this is likely a security vulnerability.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
