### PR TITLE
Fixing unaddressable bytes issue with proc net read buffer.

### DIFF
--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -127,8 +127,8 @@ int read_proc_net_from_file(
                 return_value = aws_error;
                 goto cleanup;
             }
-            size_hint += size_hint;
             read = fread(out_buf->buffer + out_buf->len, 1, size_hint, fp);
+            size_hint += size_hint;
         }
         if (ferror(fp)) {
             return_value = aws_translate_and_raise_io_error(errno);


### PR DESCRIPTION
*Description of changes:*
Running the [DeviceClient](https://github.com/awslabs/aws-iot-device-client) as a service with Valgrind revealed a segfault issue with the Device Defender feature on device reboot. 

The issue is that there were unaddressable bytes when reading from proc net to an output buffer. When the byte buffer's size is expanded by `size_hint` items, we should read at most `size_hint` more items into the buffer. Therefore, the value of `size_hint` should only be doubled after that read is done, instead of before.

Valgrind trace below:

```
==818== Memcheck, a memory error detector
==818== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==818== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==818== Command: /sbin/aws-iot-device-client-bin
==818== Parent PID: 817
==818==
==818== Thread 3:
==818== Syscall param read(buf) points to unaddressable byte(s)
==818==  at 0x617F184: read (read.c:27)
==818==  by 0x60FA741: _IO_file_xsgetn (fileops.c:1364)
==818==  by 0x60EE4A0: fread (iofread.c:38)
==818==  by 0x3042F1: read_proc_net_from_file (network.c:131)
==818==  by 0x304B02: get_network_connections (network.c:283)
==818==  by 0x301DB8: s_reporting_task_fn (device_defender.c:344)
==818==  by 0x2F439B: aws_task_run (task_scheduler.c:43)
==818==  by 0x2F4BDC: s_run_all (task_scheduler.c:246)
==818==  by 0x2F49FF: aws_task_scheduler_run_all (task_scheduler.c:185)
==818==  by 0x2064B8: s_main_loop (epoll_event_loop.c:617)
==818==  by 0x2F90DE: thread_fn (thread.c:39)
==818==  by 0x5E576DA: start_thread (pthread_create.c:463)
==818== Address 0x67a6c30 is 0 bytes after a block of size 8,192 alloc'd
==818==  at 0x4C33D2F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==818==  by 0x2DCA23: s_default_realloc (allocator.c:46)
==818==  by 0x2DD0D5: aws_mem_realloc (allocator.c:187)
==818==  by 0x2EFE5C: s_trace_mem_realloc (memtrace.c:438)
==818==  by 0x2DD0D5: aws_mem_realloc (allocator.c:187)
==818==  by 0x2E1305: aws_byte_buf_reserve (byte_buf.c:754)
==818==  by 0x2E1447: aws_byte_buf_reserve_relative (byte_buf.c:775)
==818==  by 0x3042B1: read_proc_net_from_file (network.c:126)
==818==  by 0x304B02: get_network_connections (network.c:283)
==818==  by 0x301DB8: s_reporting_task_fn (device_defender.c:344)
==818==  by 0x2F439B: aws_task_run (task_scheduler.c:43)
==818==  by 0x2F4BDC: s_run_all (task_scheduler.c:246)
==818==
--818-- VALGRIND INTERNAL ERROR: Valgrind received a signal 11 (SIGSEGV) - exiting
--818-- si_code=128; Faulting address: 0x0; sp: 0x1006542e20
valgrind: the 'impossible' happened:
  Killed by fatal signal
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
