### PR TITLE
Handle websocket shutdown

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -62,6 +62,14 @@ struct aws_secure_tunneling_connection_config {
     void *user_data;
 };
 
+struct ping_task_context {
+    struct aws_allocator *allocator;
+    struct aws_event_loop *event_loop;
+
+    bool task_cancelled;
+    struct aws_websocket *websocket;
+};
+
 struct aws_secure_tunnel {
     /* Static settings */
     struct aws_secure_tunneling_connection_config config;
@@ -82,6 +90,7 @@ struct aws_secure_tunnel {
     /* The secure tunneling endpoint ELB drops idle connect after 1 minute. We need to send a ping periodically to keep
      * the connection */
     struct aws_task ping_task;
+    struct ping_task_context *ping_task_context;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -83,7 +83,6 @@ struct aws_secure_tunnel {
 
     /* The secure tunneling endpoint ELB drops idle connect after 1 minute. We need to send a ping periodically to keep
      * the connection */
-    struct aws_task ping_task;
     struct ping_task_context *ping_task_context;
 };
 

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -62,13 +62,7 @@ struct aws_secure_tunneling_connection_config {
     void *user_data;
 };
 
-struct ping_task_context {
-    struct aws_allocator *allocator;
-    struct aws_event_loop *event_loop;
-
-    bool task_cancelled;
-    struct aws_websocket *websocket;
-};
+struct ping_task_context;
 
 struct aws_secure_tunnel {
     /* Static settings */

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -26,6 +26,7 @@ typedef int(aws_secure_tunneling_close_fn)(struct aws_secure_tunnel *secure_tunn
 
 /* Callbacks */
 typedef void(aws_secure_tunneling_on_connection_complete_fn)(void *user_data);
+typedef void(aws_secure_tunneling_on_connection_shutdown_fn)(void *user_data);
 typedef void(aws_secure_tunneling_on_send_data_complete_fn)(int error_code, void *user_data);
 typedef void(aws_secure_tunneling_on_data_receive_fn)(const struct aws_byte_buf *data, void *user_data);
 typedef void(aws_secure_tunneling_on_stream_start_fn)(void *user_data);
@@ -51,6 +52,7 @@ struct aws_secure_tunneling_connection_config {
     const char *root_ca;
 
     aws_secure_tunneling_on_connection_complete_fn *on_connection_complete;
+    aws_secure_tunneling_on_connection_shutdown_fn *on_connection_shutdown;
     aws_secure_tunneling_on_send_data_complete_fn *on_send_data_complete;
     aws_secure_tunneling_on_data_receive_fn *on_data_receive;
     aws_secure_tunneling_on_stream_start_fn *on_stream_start;

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -89,7 +89,8 @@ static void s_on_websocket_setup(
     secure_tunnel->ping_task_context = ping_task_context;
     AWS_ZERO_STRUCT(*ping_task_context);
     ping_task_context->allocator = secure_tunnel->config.allocator;
-    ping_task_context->event_loop = aws_event_loop_group_get_next_loop(secure_tunnel->config.bootstrap->event_loop_group);
+    ping_task_context->event_loop =
+        aws_event_loop_group_get_next_loop(secure_tunnel->config.bootstrap->event_loop_group);
     aws_atomic_store_int(&ping_task_context->task_cancelled, 0);
     ping_task_context->websocket = websocket;
 

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -11,6 +11,7 @@
 #define INVALID_STREAM_ID 0
 #define MAX_ST_PAYLOAD 64512
 #define PAYLOAD_BYTE_LENGTH_PREFIX 2
+#define PING_TASK_INTERVAL ((uint64_t)20 * 1000000000)
 
 #define UNUSED(x) (void)(x)
 
@@ -26,17 +27,27 @@ static void s_send_websocket_ping(struct aws_websocket *websocket) {
     aws_websocket_send_frame(websocket, &frame_options);
 }
 
+struct ping_task_context {
+    struct aws_allocator *allocator;
+    struct aws_event_loop *event_loop;
+
+    struct aws_atomic_var task_cancelled;
+    struct aws_websocket *websocket;
+};
+
 static void s_ping_task(struct aws_task *task, void *user_data, enum aws_task_status task_status) {
     AWS_LOGF_TRACE(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "s_ping_task");
 
     if (task_status != AWS_TASK_STATUS_RUN_READY) {
-        AWS_LOGF_ERROR(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "task_status is not ready. Do nothing.");
+        AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "task_status is not ready. Do nothing.");
         return;
     }
 
     struct ping_task_context *ping_task_context = user_data;
-    if (ping_task_context->task_cancelled) {
+    const size_t task_cancelled = aws_atomic_load_int(&ping_task_context->task_cancelled);
+    if (task_cancelled) {
         AWS_LOGF_TRACE(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "ping task is cancelled");
+        aws_event_loop_cancel_task(ping_task_context->event_loop, task);
         aws_mem_release(ping_task_context->allocator, ping_task_context);
         return;
     }
@@ -46,7 +57,7 @@ static void s_ping_task(struct aws_task *task, void *user_data, enum aws_task_st
     /* Schedule the next task */
     uint64_t now;
     aws_event_loop_current_clock_time(ping_task_context->event_loop, &now);
-    aws_event_loop_schedule_task_future(ping_task_context->event_loop, task, now + (uint64_t)20 * 1000000000);
+    aws_event_loop_schedule_task_future(ping_task_context->event_loop, task, now + PING_TASK_INTERVAL);
 }
 
 static void s_on_websocket_setup(
@@ -73,9 +84,17 @@ static void s_on_websocket_setup(
     secure_tunnel->websocket = websocket;
     secure_tunnel->config.on_connection_complete(secure_tunnel->config.user_data);
 
-    secure_tunnel->ping_task_context->task_cancelled = false;
-    secure_tunnel->ping_task_context->websocket = websocket;
-    aws_event_loop_schedule_task_now(secure_tunnel->ping_task_context->event_loop, &secure_tunnel->ping_task);
+    struct ping_task_context *ping_task_context =
+        aws_mem_acquire(secure_tunnel->config.allocator, sizeof(struct ping_task_context));
+    secure_tunnel->ping_task_context = ping_task_context;
+    AWS_ZERO_STRUCT(*ping_task_context);
+    ping_task_context->allocator = secure_tunnel->config.allocator;
+    ping_task_context->event_loop = aws_event_loop_group_get_next_loop(secure_tunnel->config.bootstrap->event_loop_group);
+    aws_atomic_store_int(&ping_task_context->task_cancelled, 0);
+    ping_task_context->websocket = websocket;
+
+    aws_task_init(&secure_tunnel->ping_task, s_ping_task, ping_task_context, "SecureTunnelingPingTask");
+    aws_event_loop_schedule_task_now(ping_task_context->event_loop, &secure_tunnel->ping_task);
 }
 
 static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_code, void *user_data) {
@@ -83,7 +102,7 @@ static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_c
     UNUSED(error_code);
 
     struct aws_secure_tunnel *secure_tunnel = user_data;
-    secure_tunnel->ping_task_context->task_cancelled = true;
+    aws_atomic_store_int(&secure_tunnel->ping_task_context->task_cancelled, 1);
     secure_tunnel->ping_task_context->websocket = NULL;
     secure_tunnel->config.on_connection_shutdown(secure_tunnel->config.user_data);
 }
@@ -496,14 +515,6 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
 
     /* TODO: Release this buffer when there is no data to hold */
     aws_byte_buf_init(&secure_tunnel->received_data, connection_config->allocator, MAX_WEBSOCKET_PAYLOAD);
-
-    struct ping_task_context *ping_task_context =
-        aws_mem_acquire(connection_config->allocator, sizeof(struct ping_task_context));
-    secure_tunnel->ping_task_context = ping_task_context;
-    AWS_ZERO_STRUCT(*ping_task_context);
-    ping_task_context->allocator = connection_config->allocator;
-    ping_task_context->event_loop = aws_event_loop_group_get_next_loop(connection_config->bootstrap->event_loop_group);
-    aws_task_init(&secure_tunnel->ping_task, s_ping_task, ping_task_context, "SecureTunnelingPingTask");
 
     return secure_tunnel;
 }

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -50,7 +50,6 @@ static void s_ping_task(struct aws_task *task, void *user_data, enum aws_task_st
     const size_t task_cancelled = aws_atomic_load_int(&ping_task_context->task_cancelled);
     if (task_cancelled) {
         AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "task_cancelled is true. Cleaning up ping task.");
-        aws_event_loop_cancel_task(ping_task_context->event_loop, task);
         aws_mem_release(ping_task_context->allocator, ping_task_context);
         return;
     }

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -31,6 +31,7 @@ struct ping_task_context {
     struct aws_allocator *allocator;
     struct aws_event_loop *event_loop;
 
+    struct aws_task ping_task;
     struct aws_atomic_var task_cancelled;
     struct aws_websocket *websocket;
 };
@@ -96,8 +97,8 @@ static void s_on_websocket_setup(
     aws_atomic_store_int(&ping_task_context->task_cancelled, 0);
     ping_task_context->websocket = websocket;
 
-    aws_task_init(&secure_tunnel->ping_task, s_ping_task, ping_task_context, "SecureTunnelingPingTask");
-    aws_event_loop_schedule_task_now(ping_task_context->event_loop, &secure_tunnel->ping_task);
+    aws_task_init(&ping_task_context->ping_task, s_ping_task, ping_task_context, "SecureTunnelingPingTask");
+    aws_event_loop_schedule_task_now(ping_task_context->event_loop, &ping_task_context->ping_task);
 }
 
 static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_code, void *user_data) {

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -497,10 +497,11 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
     /* TODO: Release this buffer when there is no data to hold */
     aws_byte_buf_init(&secure_tunnel->received_data, connection_config->allocator, MAX_WEBSOCKET_PAYLOAD);
 
-    struct ping_task_context *ping_task_context = aws_mem_acquire(connection_config->allocator, sizeof(struct ping_task_context));
+    struct ping_task_context *ping_task_context =
+        aws_mem_acquire(connection_config->allocator, sizeof(struct ping_task_context));
     AWS_ZERO_STRUCT(*ping_task_context);
     ping_task_context->allocator = connection_config->allocator;
-    ping_task_context->event_loop =  aws_event_loop_group_get_next_loop(connection_config->bootstrap->event_loop_group);
+    ping_task_context->event_loop = aws_event_loop_group_get_next_loop(connection_config->bootstrap->event_loop_group);
     aws_task_init(&secure_tunnel->ping_task, s_ping_task, ping_task_context, "SecureTunnelingPingTask");
 
     return secure_tunnel;

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -78,7 +78,9 @@ static void s_on_websocket_setup(
 static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_code, void *user_data) {
     UNUSED(websocket);
     UNUSED(error_code);
-    UNUSED(user_data);
+
+    struct aws_secure_tunnel *secure_tunnel = user_data;
+    secure_tunnel->config.on_connection_shutdown(secure_tunnel->config.user_data);
 }
 
 static bool s_on_websocket_incoming_frame_begin(

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -499,6 +499,7 @@ struct aws_secure_tunnel *aws_secure_tunnel_new(
 
     struct ping_task_context *ping_task_context =
         aws_mem_acquire(connection_config->allocator, sizeof(struct ping_task_context));
+    secure_tunnel->ping_task_context = ping_task_context;
     AWS_ZERO_STRUCT(*ping_task_context);
     ping_task_context->allocator = connection_config->allocator;
     ping_task_context->event_loop = aws_event_loop_group_get_next_loop(connection_config->bootstrap->event_loop_group);

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -30,6 +30,10 @@ static void s_on_connection_complete(void *user_data) {
     aws_mutex_unlock(&mutex);
 }
 
+static void s_on_connection_shutdown(void *user_data) {
+    UNUSED(user_data);
+}
+
 static void s_on_data_receive(const struct aws_byte_buf *data, void *user_data) {
     AWS_LOGF_INFO(AWS_LS_IOTDEVICE_SECURE_TUNNELING, "Client received data:");
 
@@ -88,6 +92,7 @@ static void s_init_secure_tunneling_connection_config(
     config->root_ca = root_ca;
 
     config->on_connection_complete = s_on_connection_complete;
+    config->on_connection_shutdown = s_on_connection_shutdown;
     config->on_send_data_complete = s_on_send_data_complete;
     config->on_data_receive = s_on_data_receive;
     config->on_stream_start = s_on_stream_start;

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -129,6 +129,7 @@ static int before(struct aws_allocator *allocator, void *ctx) {
 }
 
 static int after(struct aws_allocator *allocator, int setup_result, void *ctx) {
+    UNUSED(allocator);
     UNUSED(setup_result);
 
     struct secure_tunneling_test_context *test_context = ctx;

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -138,7 +138,6 @@ static int after(struct aws_allocator *allocator, int setup_result, void *ctx) {
     aws_client_bootstrap_release(test_context->secure_tunnel->config.bootstrap);
     ASSERT_SUCCESS(aws_global_thread_creator_shutdown_wait_for(10));
 
-    aws_mem_release(allocator, test_context->secure_tunnel->ping_task_context);
     aws_secure_tunnel_release(test_context->secure_tunnel);
     aws_iotdevice_library_clean_up();
     aws_http_library_clean_up();


### PR DESCRIPTION
### Description of changes:
Before this change, there is no way for the client of this SDK to get notified when a websocket is closed. Therefore the client application cannot clean up the resources related to the tunnel.

This PR does the following:
* Notify client when websocket is closed.
* Skip ping task and not schedule new one when the secure tunnel is closed.

### Testing done
Tested the changes in this PR with Device Client and verified that the ping task is stopped and not sending ping to a closed websocket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
