### PR TITLE
Add improved memory deallocation handling

### DIFF
--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -10,7 +10,6 @@
 #include <aws/common/error.h>
 #include <aws/common/hash_table.h>
 #include <aws/common/logging.h>
-#include <aws/common/stdbool.h>
 #include <aws/common/string.h>
 #include <aws/io/io.h>
 
@@ -207,8 +206,7 @@ int get_net_connections_from_proc_buf(
                 goto cleanup;
             }
 
-            AWS_ZERO_STRUCT(connection->local_interface);
-            AWS_ZERO_STRUCT(connection->remote_address);
+            AWS_ZERO_STRUCT(*connection);
 
             char local_addr[IPV4_ADDRESS_SIZE];
             char remote_addr[IPV4_ADDRESS_SIZE];


### PR DESCRIPTION
This commit addresses some issues seen when running the Device Defender code shortly after machine startup, which can result in a message /net/proc/tcp file. When there are invalid lines in the file, this can trigger early memory deallocation of structs such as aws_string that have not actually been allocated. This commit resolves this issue by adding additional validation to ensure we're only deallocating memory that has actually been utilized, and also handling to ensure we don't perform a double free.

*Issue #, if available:
https://github.com/awslabs/aws-iot-device-client/issues/85

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
