### PR TITLE
Update README build steps for aws-lc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,37 +10,18 @@ This library is licensed under the Apache 2.0 License.
 
 ### Building
 
-#### Building s2n (Linux Only)
+#### Building s2n-tls (Linux Only)
 
-If you are building on Linux, you will need to build s2n before being able to build aws-c-io, which is a dependency of aws-c-auth.  For our CRT's, we build s2n at a specific commit, and recommend doing the same when using it with this library.  That commit hash can be found [here](https://github.com/awslabs/aws-crt-cpp/tree/main/crt).  The commands below will build s2n using OpenSSL 1.1.1.  For using other versions of OpenSSL, there is additional information in the [s2n Usage Guide](https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md).
+If you are building on Linux, you will need to build aws-lc and s2n-tls first.
 
 ```
-git clone git@github.com:awslabs/s2n.git
-cd s2n
-git checkout <s2n-commit-hash-used-by-aws-crt-cpp>
+git clone git@github.com:awslabs/aws-lc.git
+cmake -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-lc -B aws-lc/build
+cmake --build aws-lc/build --target install --parallel
 
-# We keep the build artifacts in the -build directory
-cd libcrypto-build
-
-# Download the latest version of OpenSSL
-curl -LO https://www.openssl.org/source/openssl-1.1.1-latest.tar.gz
-tar -xzvf openssl-1.1.1-latest.tar.gz
-
-# Build openssl libcrypto.  Note that the install path specified here must be absolute.
-cd `tar ztf openssl-1.1.1-latest.tar.gz | head -n1 | cut -f1 -d/`
-./config -fPIC no-shared              \
-         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
-         no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
-         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
-         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
-         --prefix=<absolute-install-path>
-make
-make install
-
-# Build s2n
-cd ../../../
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S s2n -B s2n/build
-cmake --build s2n/build --target install
+git clone git@github.com:aws/s2n-tls.git
+cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S s2n-tls -B s2n-tls/build
+cmake --build s2n-tls/build --target install --parallel
 ```
 
 #### Building aws-c-iot and Remaining Dependencies
@@ -50,25 +31,29 @@ Note that aws-c-iot has several dependencies that need to be built.
 ```
 git clone git@github.com:awslabs/aws-c-common.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-common -B aws-c-common/build
-cmake --build aws-c-common/build --target install
+cmake --build aws-c-common/build --target install --parallel
+
+git clone git@github.com:awslabs/aws-c-cal.git
+cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-cal -B aws-c-cal/build
+cmake --build aws-c-cal/build --target install --parallel
 
 git clone git@github.com:awslabs/aws-c-io.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-io -B aws-c-io/build
-cmake --build aws-c-io/build --target install
+cmake --build aws-c-io/build --target install --parallel
 
 git clone git@github.com:awslabs/aws-c-compression.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-compression -B aws-c-compression/build
-cmake --build aws-c-compression/build --target install
+cmake --build aws-c-compression/build --target install --parallel
 
 git clone git@github.com:awslabs/aws-c-http.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-http -B aws-c-http/build
-cmake --build aws-c-http/build --target install
+cmake --build aws-c-http/build --target install --parallel
 
 git clone git@github.com:awslabs/aws-c-mqtt.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-mqtt -B aws-c-mqtt/build
-cmake --build aws-c-mqtt/build --target install
+cmake --build aws-c-mqtt/build --target install --parallel
 
 git clone git@github.com:awslabs/aws-c-iot.git
 cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-iot -B aws-c-iot/build
-cmake --build aws-c-iot/build --target install
+cmake --build aws-c-iot/build --target install --parallel
 ```

--- a/README.md
+++ b/README.md
@@ -10,50 +10,50 @@ This library is licensed under the Apache 2.0 License.
 
 ### Building
 
+Note that aws-c-iot has several dependencies that need to be built.
+
 #### Building s2n-tls (Linux Only)
 
 If you are building on Linux, you will need to build aws-lc and s2n-tls first.
 
 ```
 git clone git@github.com:awslabs/aws-lc.git
-cmake -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-lc -B aws-lc/build
-cmake --build aws-lc/build --target install --parallel
+cmake -S aws-lc -B aws-lc/build -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-lc/build --target install
 
 git clone git@github.com:aws/s2n-tls.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S s2n-tls -B s2n-tls/build
-cmake --build s2n-tls/build --target install --parallel
+cmake -S s2n-tls -B s2n-tls/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build s2n-tls/build --target install
 ```
 
 #### Building aws-c-iot and Remaining Dependencies
 
-Note that aws-c-iot has several dependencies that need to be built.
-
 ```
 git clone git@github.com:awslabs/aws-c-common.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-common -B aws-c-common/build
-cmake --build aws-c-common/build --target install --parallel
+cmake -S aws-c-common -B aws-c-common/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-common/build --target install
 
 git clone git@github.com:awslabs/aws-c-cal.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-cal -B aws-c-cal/build
-cmake --build aws-c-cal/build --target install --parallel
+cmake -S aws-c-cal -B aws-c-cal/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-cal/build --target install
 
 git clone git@github.com:awslabs/aws-c-io.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-io -B aws-c-io/build
-cmake --build aws-c-io/build --target install --parallel
+cmake -S aws-c-io -B aws-c-io/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-io/build --target install
 
 git clone git@github.com:awslabs/aws-c-compression.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-compression -B aws-c-compression/build
-cmake --build aws-c-compression/build --target install --parallel
+cmake -S aws-c-compression -B aws-c-compression/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-compression/build --target install
 
 git clone git@github.com:awslabs/aws-c-http.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-http -B aws-c-http/build
-cmake --build aws-c-http/build --target install --parallel
+cmake -S aws-c-http -B aws-c-http/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-http/build --target install
 
 git clone git@github.com:awslabs/aws-c-mqtt.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-mqtt -B aws-c-mqtt/build
-cmake --build aws-c-mqtt/build --target install --parallel
+cmake -S aws-c-mqtt -B aws-c-mqtt/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-mqtt/build --target install
 
 git clone git@github.com:awslabs/aws-c-iot.git
-cmake -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path> -S aws-c-iot -B aws-c-iot/build
-cmake --build aws-c-iot/build --target install --parallel
+cmake -S aws-c-iot -B aws-c-iot/build -DCMAKE_PREFIX_PATH=<install-path> -DCMAKE_INSTALL_PREFIX=<install-path>
+cmake --build aws-c-iot/build --target install
 ```


### PR DESCRIPTION
[s2n](https://github.com/aws/s2n-tls) no longer relies libcrypto from openssl, now it uses libcrypto from [aws-lc](https://github.com/awslabs/aws-lc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
