### PR TITLE
First draft to prevent task from being freed while pending publishes remain

### DIFF
--- a/source/device_defender.c
+++ b/source/device_defender.c
@@ -196,6 +196,8 @@ static int s_mqtt_report_publish_fn(struct aws_byte_cursor report, void *userdat
 
     report_context->allocator = defender_task->allocator;
     report_context->defender_task = defender_task;
+
+    /* Make sure defender task stays alive until publish completes one way or another */
     aws_ref_count_acquire(&defender_task->ref_count);
 
     /* must copy the report data and make into a byte_cursor to use it for MQTT publish */
@@ -738,6 +740,7 @@ void s_defender_config_clean_up_internals(struct aws_iotdevice_defender_task_con
     aws_array_list_clean_up(&config->custom_metrics);
 }
 
+/* Final memory clean up when ref count hits zero */
 void s_defender_task_clean_up_final(struct aws_iotdevice_defender_task *defender_task) {
     aws_string_destroy(defender_task->publish_report_topic_name);
     aws_string_destroy(defender_task->report_accepted_topic_name);


### PR DESCRIPTION
Fixes a crash due to the inverted order of resource management within the device defender API.

In particular, the mqtt connection, which is injected, will naturally outlive the device defender data structures.  But the mqtt connection is configured with callbacks (for puback) that will expect the device defender data structures to be alive.  Under certain conditions (completing offline requests in the connection destruction logic), these callbacks can get invoked long after the device defender task is stopped by the user code.  We prevent this particular problem (note that this doesn't solve some other lifecycle problems) by ref counting the device defender task via (1 + # of incomplete publish operations).  In this way, publishes that complete after the public "clean_up" function is called, will still have a valid context/userdata.  Note that the device defender C++ code, does not use the callbacks.  If it did, this solution would be insufficient, because the C++ object would not be pinned and the resulting callback would likely be using a freed function object.

This PR also converts a number of acquires to callocs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
