### PR TITLE
expose private header that is currently used in downstream tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ file(GLOB AWS_IOT_PRIV_HEADERS
 
 file(GLOB AWS_IOT_PRIV_EXPOSED_HEADERS
         "include/aws/iotdevice/private/serializer.h"
+        "include/aws/iotdevice/private/secure_tunneling_impl.h"
         )
 
 file(GLOB AWS_IOT_EXTERNAL_HEADERS


### PR DESCRIPTION
**Issue:**
A previous PR https://github.com/awslabs/aws-c-iot/pull/58 moved the `struct aws_secure_tunnel` definition to a private header, for better separation of private vs public. Turns out, the internals of this struct were being accessed in [aws-iot-device-sdk-cpp-v2 tests](https://github.com/aws/aws-iot-device-sdk-cpp-v2/blob/74e0b28d7a69ef1df43158903170d1accc5b6aca/secure_tunneling/tests/SecureTunnelTest.cpp#L163).

**Description of changes:**
Install this private header (this library was already installing 1 private headers for use in downstream tests, now there are 2)

It would be better to rework the downstream tests so they aren't fiddling with the internals of their dependencies, but punting that to another day. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
