### PR TITLE
Fix bug where file descriptor 0 (aka stdin) was accidentally closed

### DIFF
--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -338,7 +338,7 @@ int get_network_config_and_transfer(struct aws_iotdevice_network_ifconfig *ifcon
         return AWS_OP_ERR;
     }
     int result = AWS_OP_ERR;
-    int fd = 0;
+    int fd = -1;
     struct ifaddrs *address_info = NULL;
     if (getifaddrs(&address_info)) {
         AWS_LOGF_ERROR(
@@ -408,8 +408,10 @@ int get_network_config_and_transfer(struct aws_iotdevice_network_ifconfig *ifcon
             goto cleanup;
         }
     next_interface:
-        close(fd);
-        fd = 0;
+        if (fd != -1) {
+            close(fd);
+            fd = -1;
+        }
         address = address->ifa_next;
     } /* while */
     result = AWS_OP_SUCCESS;
@@ -421,7 +423,7 @@ cleanup:
     if (address_info) {
         freeifaddrs(address_info);
     }
-    if (fd) {
+    if (fd != -1) {
         close(fd);
     }
     return result;


### PR DESCRIPTION
**Issue:**
aws-iot-device-client was observing failures when both DeviceDefender and SecureTunneling were enabled. We observed that SecureTunnel's socket was using file descriptor 0, which is odd because file descriptor 0 is usually used by `stdin`.

**Description of changes:**
Fix bug where file descriptor 0 was closed by accident. The code believed that 0 was an invalid value for file descriptors, but 0 is totally valid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
