### PR TITLE
Fix segmentation fault when closing secure tunnel with null websocket

### DIFF
--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -452,9 +452,11 @@ static int s_secure_tunneling_close(struct aws_secure_tunnel *secure_tunnel) {
     }
 
     s_reset_secure_tunnel(secure_tunnel);
-    secure_tunnel->websocket_vtable.close(secure_tunnel->websocket, false);
-    secure_tunnel->websocket_vtable.release(secure_tunnel->websocket);
-    secure_tunnel->websocket = NULL;
+    if (secure_tunnel->websocket != NULL) {
+        secure_tunnel->websocket_vtable.close(secure_tunnel->websocket, false);
+        secure_tunnel->websocket_vtable.release(secure_tunnel->websocket);
+        secure_tunnel->websocket = NULL;
+    }
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -47,6 +47,10 @@ struct secure_tunneling_test_context {
 };
 static struct secure_tunneling_test_context s_test_context = {.max_threads = 1};
 
+/* Dummy websocket for  */
+struct aws_websocket { };
+static struct aws_websocket s_aws_websocket = { };
+
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(void *user_data) {
     UNUSED(user_data);
@@ -154,6 +158,18 @@ static struct aws_secure_tunnel *s_secure_tunnel_new_mock(const struct aws_secur
     secure_tunnel->websocket_vtable.send_frame = s_mock_aws_websocket_send_frame;
     secure_tunnel->websocket_vtable.close = s_mock_aws_websocket_close;
     secure_tunnel->websocket_vtable.release = s_mock_aws_websocket_release;
+
+    /*
+     * Initialize a dummy websocket when the tunnel is created.
+     *
+     * In the non-mock implementation this websocket would be initialized when
+     * an http upgrade request is received sometime after the tunnel is created.
+     *
+     * Since no http request is exercised by these tests we initialize a dummy
+     * websocket as soon as the tunnel is created.
+     */
+    secure_tunnel->websocket = &s_aws_websocket;
+
     return secure_tunnel;
 }
 

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -48,8 +48,10 @@ struct secure_tunneling_test_context {
 static struct secure_tunneling_test_context s_test_context = {.max_threads = 1};
 
 /* Dummy websocket for unit test only. */
-struct aws_websocket {};
-static struct aws_websocket s_aws_websocket;
+struct aws_websocket {
+    int dummy;
+};
+static struct aws_websocket s_aws_websocket = {0};
 
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(void *user_data) {

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -47,9 +47,9 @@ struct secure_tunneling_test_context {
 };
 static struct secure_tunneling_test_context s_test_context = {.max_threads = 1};
 
-/* Dummy websocket for  */
+/* Dummy websocket for unit test only. */
 struct aws_websocket {};
-static struct aws_websocket s_aws_websocket = {};
+static struct aws_websocket s_aws_websocket;
 
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(void *user_data) {

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -48,8 +48,8 @@ struct secure_tunneling_test_context {
 static struct secure_tunneling_test_context s_test_context = {.max_threads = 1};
 
 /* Dummy websocket for  */
-struct aws_websocket { };
-static struct aws_websocket s_aws_websocket = { };
+struct aws_websocket {};
+static struct aws_websocket s_aws_websocket = {};
 
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(void *user_data) {

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -47,12 +47,6 @@ struct secure_tunneling_test_context {
 };
 static struct secure_tunneling_test_context s_test_context = {.max_threads = 1};
 
-/* Dummy websocket for unit test only. */
-struct aws_websocket {
-    int dummy;
-};
-static struct aws_websocket s_aws_websocket = {0};
-
 static bool s_on_stream_start_called = false;
 static void s_on_stream_start(void *user_data) {
     UNUSED(user_data);
@@ -167,10 +161,11 @@ static struct aws_secure_tunnel *s_secure_tunnel_new_mock(const struct aws_secur
      * In the non-mock implementation this websocket would be initialized when
      * an http upgrade request is received sometime after the tunnel is created.
      *
-     * Since no http request is exercised by these tests we initialize a dummy
-     * websocket as soon as the tunnel is created.
+     * Since no http request is exercised by these tests we initialize a websocket
+     * as soon as the tunnel is created. Since the aws_websocket struct is opaque
+     * to this module, we use the placeholder value 1 to set the member non-null.
      */
-    secure_tunnel->websocket = &s_aws_websocket;
+    secure_tunnel->websocket = (void *)1;
 
     return secure_tunnel;
 }


### PR DESCRIPTION
* The websocket associated with a secure tunnel is initialized to NULL
  when a secure tunnel is created.
* The NULL websocket member of secure tunnel will be replaced with a
  non-NULL reference when a http upgrade request is received to upgrade
  a plain http socket connection to a websocket.
* The aws_secure_tunnel_close function assumes that the websocket
  member is always non-NULL. As a result, calling this function on
  secure tunnel that is initialized but hasn't yet initialized the
  websocket member will result in a segmentation fault.
* This commit adds a NULL check on the websocket member inside
  of the aws_secure_tunnel_close function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
