### PR TITLE
Fix segmentation fault when closing secure tunnel from destination de…

### DIFF
--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -70,6 +70,9 @@ AWS_IOTDEVICE_API
 void aws_secure_tunnel_release(struct aws_secure_tunnel *secure_tunnel);
 
 AWS_IOTDEVICE_API
+void aws_secure_tunnel_clear_connection_shutdown_callback(struct aws_secure_tunnel *secure_tunnel);
+
+AWS_IOTDEVICE_API
 int aws_secure_tunnel_connect(struct aws_secure_tunnel *secure_tunnel);
 
 AWS_IOTDEVICE_API

--- a/source/secure_tunneling.c
+++ b/source/secure_tunneling.c
@@ -219,7 +219,9 @@ static void s_on_websocket_shutdown(struct aws_websocket *websocket, int error_c
     struct aws_secure_tunnel *secure_tunnel = user_data;
     aws_atomic_store_int(&secure_tunnel->ping_task_context->task_cancelled, 1);
     secure_tunnel->ping_task_context->websocket = NULL;
-    secure_tunnel->options->on_connection_shutdown(secure_tunnel->options->user_data);
+    if (secure_tunnel->options->on_connection_shutdown != NULL) {
+        secure_tunnel->options->on_connection_shutdown(secure_tunnel->options->user_data);
+    }
 }
 
 static bool s_on_websocket_incoming_frame_begin(
@@ -694,6 +696,14 @@ void aws_secure_tunnel_release(struct aws_secure_tunnel *secure_tunnel) {
         return;
     }
     aws_ref_count_release(&secure_tunnel->ref_count);
+}
+
+void aws_secure_tunnel_clear_connection_shutdown_callback(struct aws_secure_tunnel *secure_tunnel) {
+    if (secure_tunnel != NULL) {
+        if (secure_tunnel->options != NULL) {
+            secure_tunnel->options->on_connection_shutdown = NULL;
+        }
+    }
 }
 
 static void s_secure_tunnel_destroy(void *user_data) {


### PR DESCRIPTION
In Device Client, for Secure Tunneling feature, we are seeing a race condition where on 1 thread we are calling destructor to destroy the secure tunnel object and on other thread the call back method for secure tunnel connection close is called. Since the object is destroyed, the call back method is failing to find the object and eventually failing with segmentation fault.

To resolve this issue, I have created a new method `aws_secure_tunnel_clear_connection_shutdown_callback` to manually set `on_connection_shutdown` to `NULL`. This way, if the callback method is updated to `NULL`, we will not get any call back after connection is closed and the issue will be resolved. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
