### PR TITLE
Add secure tunnel connection_error_code and API to access it

### DIFF
--- a/include/aws/iotdevice/private/secure_tunneling_impl.h
+++ b/include/aws/iotdevice/private/secure_tunneling_impl.h
@@ -58,6 +58,9 @@ struct aws_secure_tunnel {
     /* Stores what has been received but not processed */
     struct aws_byte_buf received_data;
 
+    /* Error code of last connection attempt */
+    int connection_error_code;
+
     /* The secure tunneling endpoint ELB drops idle connect after 1 minute. We need to send a ping periodically to keep
      * the connection */
 

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -69,6 +69,9 @@ AWS_IOTDEVICE_API
 struct aws_secure_tunnel *aws_secure_tunnel_acquire(struct aws_secure_tunnel *secure_tunnel);
 
 AWS_IOTDEVICE_API
+int aws_secure_tunnel_get_connection_error_code(struct aws_secure_tunnel *secure_tunnel);
+
+AWS_IOTDEVICE_API
 void aws_secure_tunnel_release(struct aws_secure_tunnel *secure_tunnel);
 
 AWS_IOTDEVICE_API


### PR DESCRIPTION
When connecting with secure tunnel, the connection_error_code member is now updated prior to calling the on_connection_complete callback to allow users to check whether an error occurred.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
