### PR TITLE
Fix library initialization

### DIFF
--- a/source/iotdevice.c
+++ b/source/iotdevice.c
@@ -15,6 +15,9 @@
 /* clang-format off */
 static struct aws_error_info s_errors[] = {
     AWS_DEFINE_ERROR_INFO_IOTDEVICE(
+        AWS_ERROR_IOTDEVICE_INVALID_RESERVED_BITS,
+        "Bits marked as reserved were incorrectly set"),
+    AWS_DEFINE_ERROR_INFO_IOTDEVICE(
         AWS_ERROR_IOTDEVICE_DEFENDER_INVALID_REPORT_INTERVAL,
         "Invalid defender task reporting interval. Must be greater than 5 minutes"),
     AWS_DEFINE_ERROR_INFO_IOTDEVICE(
@@ -62,23 +65,25 @@ static bool s_iotdevice_library_initialized = false;
 
 void aws_iotdevice_library_init(struct aws_allocator *allocator) {
     AWS_PRECONDITION(aws_allocator_is_valid(allocator));
-    (void)(allocator); // ignore unused warning
 
     if (!s_iotdevice_library_initialized) {
+        s_iotdevice_library_initialized = true;
+
+        aws_mqtt_library_init(allocator);
         aws_register_error_info(&s_error_list);
         aws_register_log_subject_info_list(&s_logging_subjects_list);
-
-        s_iotdevice_library_initialized = true;
     }
 }
 
 void aws_iotdevice_library_clean_up(void) {
     if (s_iotdevice_library_initialized) {
+        s_iotdevice_library_initialized = false;
+
         aws_thread_join_all_managed();
 
         aws_unregister_error_info(&s_error_list);
         aws_unregister_log_subject_info_list(&s_logging_subjects_list);
 
-        s_iotdevice_library_initialized = false;
+        aws_mqtt_library_clean_up();
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,10 @@ include(AwsTestHarness)
 enable_testing()
 
 file(GLOB TEST_HDRS "mqtt_mock_structs.h")
-set(TEST_SRC metrics_tests.c secure_tunneling_tests.c)
+set(TEST_SRC iotdevice_tests.c metrics_tests.c secure_tunneling_tests.c)
 file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
+add_test_case(library_init)
 add_test_case(devicedefender_task_unsupported_report_format)
 
 # Network metrics are only implemented for Linux so far

--- a/tests/aws_iot_devicedefender_client_test.c
+++ b/tests/aws_iot_devicedefender_client_test.c
@@ -227,7 +227,6 @@ int main(int argc, char **argv) {
     args.mutex = &mutex;
     args.condition_variable = &condition_variable;
 
-    aws_mqtt_library_init(args.allocator);
     aws_iotdevice_library_init(args.allocator);
 
     struct aws_logger_standard_options logger_options = {
@@ -352,7 +351,6 @@ int main(int argc, char **argv) {
     aws_logger_clean_up(&logger);
 
     aws_iotdevice_library_clean_up();
-    aws_mqtt_library_clean_up();
 
     ASSERT_UINT_EQUALS(0, aws_mem_tracer_count(allocator));
     allocator = aws_mem_tracer_destroy(allocator);

--- a/tests/aws_iot_secure_tunneling_client_test.c
+++ b/tests/aws_iot_secure_tunneling_client_test.c
@@ -119,7 +119,6 @@ int main(int argc, char **argv) {
 
     struct aws_allocator *allocator = aws_mem_tracer_new(aws_default_allocator(), NULL, AWS_MEMTRACE_BYTES, 0);
 
-    aws_http_library_init(allocator);
     aws_iotdevice_library_init(allocator);
 
     struct aws_logger_standard_options logger_options = {
@@ -191,7 +190,6 @@ int main(int argc, char **argv) {
     aws_event_loop_group_release(elg);
     aws_logger_clean_up(&logger);
     aws_iotdevice_library_clean_up();
-    aws_http_library_clean_up();
 
     ASSERT_UINT_EQUALS(0, aws_mem_tracer_count(allocator));
     allocator = aws_mem_tracer_destroy(allocator);

--- a/tests/iotdevice_tests.c
+++ b/tests/iotdevice_tests.c
@@ -1,0 +1,15 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/iotdevice/iotdevice.h>
+#include <aws/testing/aws_test_harness.h>
+
+static int s_library_init(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    aws_iotdevice_library_init(allocator);
+    aws_iotdevice_library_clean_up();
+    return 0;
+}
+
+AWS_TEST_CASE(library_init, s_library_init);

--- a/tests/metrics_tests.c
+++ b/tests/metrics_tests.c
@@ -421,7 +421,7 @@ static int s_devicedefender_get_network_connections(struct aws_allocator *alloca
 }
 
 static int s_setup_mqtt_test_data_fn(struct aws_allocator *allocator, void *ctx) {
-    aws_mqtt_library_init(allocator);
+    aws_iotdevice_library_init(allocator);
 
     struct mqtt_connection_test_data *state_test_data = ctx;
     AWS_ZERO_STRUCT(*state_test_data);
@@ -472,7 +472,6 @@ static int s_clean_up_mqtt_test_data_fn(struct aws_allocator *allocator, int set
     }
 
     aws_iotdevice_library_clean_up();
-    aws_mqtt_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -502,7 +501,6 @@ static int s_publish_fn_copy_report(struct aws_byte_cursor payload, void *userda
 static int s_devicedefender_success_test(struct aws_allocator *allocator, void *ctx) {
     (void)allocator;
     struct mqtt_connection_test_data *state_test_data = ctx;
-    aws_iotdevice_library_init(state_test_data->allocator);
 
     struct aws_iotdevice_defender_task_config *task_config = NULL;
     struct aws_byte_cursor thing_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("TestSuccessThing");
@@ -547,7 +545,6 @@ static int s_devicedefender_custom_metrics_success_test(struct aws_allocator *al
     (void)allocator;
     struct mqtt_connection_test_data *state_test_data = ctx;
 
-    aws_iotdevice_library_init(state_test_data->allocator);
     struct aws_byte_cursor thing_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("TestCustomMetricSuccessThing");
     struct aws_iotdevice_defender_task_config *task_config = NULL;
     ASSERT_SUCCESS(aws_iotdevice_defender_config_create(&task_config, allocator, &thing_name, AWS_IDDRF_JSON));
@@ -625,7 +622,6 @@ static int s_devicedefender_stop_while_running(struct aws_allocator *allocator, 
     (void)allocator;
     struct mqtt_connection_test_data *state_test_data = ctx;
 
-    aws_iotdevice_library_init(state_test_data->allocator);
     struct aws_byte_cursor thing_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("TestCustomMetricSuccessThing");
     struct aws_iotdevice_defender_task_config *task_config = NULL;
     ASSERT_SUCCESS(aws_iotdevice_defender_config_create(&task_config, allocator, &thing_name, AWS_IDDRF_JSON));
@@ -687,7 +683,6 @@ static int s_devicedefender_publish_failure_callback_invoked(struct aws_allocato
     (void)allocator;
     struct mqtt_connection_test_data *state_test_data = ctx;
 
-    aws_iotdevice_library_init(state_test_data->allocator);
     struct aws_byte_cursor thing_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("TestCustomMetricSuccessThing");
     struct aws_iotdevice_defender_task_config *task_config = NULL;
     ASSERT_SUCCESS(aws_iotdevice_defender_config_create(&task_config, allocator, &thing_name, AWS_IDDRF_JSON));

--- a/tests/secure_tunneling_tests.c
+++ b/tests/secure_tunneling_tests.c
@@ -180,8 +180,7 @@ static struct aws_secure_tunnel *s_secure_tunnel_new_mock(const struct aws_secur
 static int before(struct aws_allocator *allocator, void *ctx) {
     struct secure_tunneling_test_context *test_context = ctx;
 
-    /* Initialize aws-c-http and aws-c-iot libraries. */
-    aws_http_library_init(allocator);
+    /* Initialize aws-c-iot library. */
     aws_iotdevice_library_init(allocator);
 
     /* Initialize event loop. */
@@ -246,7 +245,6 @@ static int after(struct aws_allocator *allocator, int setup_result, void *ctx) {
     aws_thread_join_all_managed();
 
     aws_iotdevice_library_clean_up();
-    aws_http_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
- Fix errors being reported incorrectly
    -  error names were off-by-one due to missing entry in s_errors
- `aws_iotdevice_library_init()` now initializes the libraries it depends on

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
