### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-iot
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.40
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-iot
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/include/aws/iotdevice/device_defender.h
+++ b/include/aws/iotdevice/device_defender.h
@@ -8,6 +8,8 @@
 
 #include <aws/iotdevice/iotdevice.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_byte_cursor;
 struct aws_array_list;
 struct aws_event_loop;
@@ -369,5 +371,6 @@ AWS_IOTDEVICE_API
 void aws_iotdevice_defender_task_clean_up(struct aws_iotdevice_defender_task *defender_task);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif

--- a/include/aws/iotdevice/iotdevice.h
+++ b/include/aws/iotdevice/iotdevice.h
@@ -9,6 +9,8 @@
 
 #include <aws/mqtt/mqtt.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #define AWS_C_IOTDEVICE_PACKAGE_ID 13
 
 enum aws_iotdevice_error {
@@ -66,5 +68,6 @@ AWS_IOTDEVICE_API
 void aws_iotdevice_library_clean_up(void);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif

--- a/include/aws/iotdevice/secure_tunneling.h
+++ b/include/aws/iotdevice/secure_tunneling.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/byte_buf.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #define AWS_IOT_ST_SPLIT_MESSAGE_SIZE 15000
 
 struct aws_secure_tunnel;
@@ -335,5 +337,6 @@ int aws_secure_tunnel_stream_reset(
     const struct aws_secure_tunnel_message_view *message_options);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_IOTDEVICE_SECURE_TUNNELING_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.