### PR TITLE
Use helper function from aws-c-common to read "special files"

### DIFF
--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -105,48 +105,6 @@ void get_network_total_delta(
     delta->packets_out = curr_total->packets_out - prev_total->packets_out;
 }
 
-int read_proc_net_from_file(
-    struct aws_byte_buf *out_buf,
-    struct aws_allocator *allocator,
-    size_t size_hint,
-    const char *filename) {
-    AWS_ZERO_STRUCT(*out_buf);
-    int return_value = AWS_OP_ERR;
-
-    if (aws_byte_buf_init(out_buf, allocator, size_hint)) {
-        return aws_raise_error(aws_last_error());
-    }
-
-    FILE *fp = fopen(filename, "r");
-    if (fp) {
-        size_t read = fread(out_buf->buffer, 1, out_buf->capacity, fp);
-        out_buf->len += read;
-        while (read == size_hint) {
-            int aws_error = 0;
-            if (AWS_OP_SUCCESS != (aws_error = aws_byte_buf_reserve_relative(out_buf, size_hint))) {
-                return_value = aws_error;
-                goto cleanup;
-            }
-            read = fread(out_buf->buffer + out_buf->len, 1, size_hint, fp);
-            size_hint += size_hint;
-        }
-        if (ferror(fp)) {
-            return_value = aws_translate_and_raise_io_error(errno);
-            goto cleanup;
-        }
-        return_value = AWS_OP_SUCCESS;
-    }
-
-cleanup:
-    fclose(fp);
-    if (AWS_OP_SUCCESS != return_value) {
-        aws_byte_buf_clean_up_secure(out_buf);
-        return aws_raise_error(return_value);
-    }
-
-    return return_value;
-}
-
 int get_net_connections_from_proc_buf(
     struct aws_array_list *net_conns,
     struct aws_allocator *allocator,
@@ -282,7 +240,7 @@ int get_network_connections(
     AWS_ZERO_STRUCT(net_udp);
     int return_code = AWS_OP_ERR;
 
-    if (read_proc_net_from_file(&net_tcp, allocator, s_proc_net_tcp_size_hint, "/proc/net/tcp")) {
+    if (aws_byte_buf_init_from_special_file(&net_tcp, allocator, "/proc/net/tcp", s_proc_net_tcp_size_hint)) {
         AWS_LOGF_ERROR(
             AWS_LS_IOTDEVICE_NETWORK_CONFIG,
             "id=%p: Failed to retrieve network configuration: %s",
@@ -292,7 +250,7 @@ int get_network_connections(
     }
     s_proc_net_tcp_size_hint = net_tcp.len * PROC_NET_HINT_FACTOR;
 
-    if (read_proc_net_from_file(&net_udp, allocator, s_proc_net_udp_size_hint, "/proc/net/udp")) {
+    if (aws_byte_buf_init_from_special_file(&net_udp, allocator, "/proc/net/udp", s_proc_net_udp_size_hint)) {
         AWS_LOGF_ERROR(
             AWS_LS_IOTDEVICE_NETWORK_CONFIG,
             "id=%p: Failed to retrieve network configuration: %s",

--- a/source/linux/network.c
+++ b/source/linux/network.c
@@ -240,7 +240,7 @@ int get_network_connections(
     AWS_ZERO_STRUCT(net_udp);
     int return_code = AWS_OP_ERR;
 
-    if (aws_byte_buf_init_from_special_file(&net_tcp, allocator, "/proc/net/tcp", s_proc_net_tcp_size_hint)) {
+    if (aws_byte_buf_init_from_file_with_size_hint(&net_tcp, allocator, "/proc/net/tcp", s_proc_net_tcp_size_hint)) {
         AWS_LOGF_ERROR(
             AWS_LS_IOTDEVICE_NETWORK_CONFIG,
             "id=%p: Failed to retrieve network configuration: %s",
@@ -250,7 +250,7 @@ int get_network_connections(
     }
     s_proc_net_tcp_size_hint = net_tcp.len * PROC_NET_HINT_FACTOR;
 
-    if (aws_byte_buf_init_from_special_file(&net_udp, allocator, "/proc/net/udp", s_proc_net_udp_size_hint)) {
+    if (aws_byte_buf_init_from_file_with_size_hint(&net_udp, allocator, "/proc/net/udp", s_proc_net_udp_size_hint)) {
         AWS_LOGF_ERROR(
             AWS_LS_IOTDEVICE_NETWORK_CONFIG,
             "id=%p: Failed to retrieve network configuration: %s",


### PR DESCRIPTION
In the past, aws-c-common didn't have functions for reading "special files" that lie about their size, but now it does: https://github.com/awslabs/aws-c-common/pull/1064
so use them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
