### PR TITLE
Adapt to aws-c-http changing `port` from 16 to 32bits

### DIFF
--- a/source/secure_tunneling_operations.c
+++ b/source/secure_tunneling_operations.c
@@ -782,7 +782,7 @@ void aws_secure_tunnel_options_storage_log(
             log_handle,
             level,
             AWS_LS_IOTDEVICE_SECURE_TUNNELING,
-            "id=%p: aws_secure_tunnel_options_storage http proxy port set to %" PRIu16,
+            "id=%p: aws_secure_tunnel_options_storage http proxy port set to %" PRIu32,
             (void *)options_storage,
             options_storage->http_proxy_options.port);
 


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
