### PR TITLE
Add USE_EXTERNAL_DEPS_SOURCES cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,14 @@ list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
 
 if (USE_EXTERNAL_DEPS_SOURCES)
     set(IN_SOURCE_BUILD ON)
+
+    if (NOT aws-c-common_SOURCE_DIR)
+        message(FATAL_ERROR "USE_EXTERNAL_DEPS_SOURCES option is set, but aws-c-common project is not configured."
+            " aws-c-common must be added using add_subdirectory command (or one of the higher-level commands that"
+            " uses add_subdirectory, like FetchContent)")
+    endif()
+
+    list(APPEND CMAKE_MODULE_PATH "${aws-c-common_SOURCE_DIR}/cmake")
 endif()
 
 include(AwsCFlags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ if (POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW) # Enable LTO/IPO if available in the compiler, see AwsCFlags
 endif()
 
+option(USE_EXTERNAL_DEPS_SOURCES "Use dependencies provided by add_subdirectory command" OFF)
+
 if (DEFINED CMAKE_PREFIX_PATH)
     file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)
 endif()
@@ -24,6 +26,10 @@ set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
 string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
 # Append that generated list to the module search path
 list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
+
+if (USE_EXTERNAL_DEPS_SOURCES)
+    set(IN_SOURCE_BUILD ON)
+endif()
 
 include(AwsCFlags)
 include(AwsCheckHeaders)


### PR DESCRIPTION
Add a new cmake option, USE_EXTERNAL_DEPS_SOURCES. When building dependencies is turned off, this new option will signal that the dependencies are provided not as installed libraries, but rather as subprojects (i.e. added previously using add_subdirectory command).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
