### PR TITLE
make exports consistent

### DIFF
--- a/include/aws/iotdevice/exports.h
+++ b/include/aws/iotdevice/exports.h
@@ -7,7 +7,7 @@
 #define AWS_IOTDEVICE_EXPORTS_H
 
 /* clang-format off */
-#if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32)
+#if defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32)
 #    ifdef AWS_IOTDEVICE_USE_IMPORT_EXPORT
 #        ifdef AWS_IOTDEVICE_EXPORTS
 #            define AWS_IOTDEVICE_API __declspec(dllexport)
@@ -19,13 +19,13 @@
 #    endif /* USE_IMPORT_EXPORT */
 
 #else
-#    if ((__GNUC__ >= 4) || defined(__clang__)) && defined(AWS_IOTDEVICE_USE_IMPORT_EXPORT) && defined(AWS_IOTDEVICE_EXPORTS)
+#    if defined(AWS_IOTDEVICE_USE_IMPORT_EXPORT) && defined(AWS_IOTDEVICE_EXPORTS)
 #        define AWS_IOTDEVICE_API __attribute__((visibility("default")))
 #    else
 #        define AWS_IOTDEVICE_API
-#    endif /* __GNUC__ >= 4 || defined(__clang__) */
+#    endif
 
-#endif /* defined(USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32) */
+#endif /* defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32) */
 /* clang-format on */
 
 #endif /* AWS_IOTDEVICE_EXPORTS_H */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make AWS_CRT_USE_WINDOWS_DLL_SEMANTICS the variable for forcing win semantics
remove gcc < 4



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
