### PR TITLE
builder -> v0.9.92 and clang-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.73
+  BUILDER_VERSION: v0.9.92
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-iot
@@ -67,6 +67,7 @@ jobs:
           - clang-11
           - clang-15
           - clang-17
+          - clang-latest
           - gcc-4.8
           - gcc-5
           - gcc-6


### PR DESCRIPTION
Update builder version to v0.9.92.
Add clang-latest to linux-compiler-compat matrix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
